### PR TITLE
Enable using MesaLink as an alternative TLS backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
+        features:
+          - ""
+          - "mesalink"
     runs-on: ${{ matrix.platform }}
     steps:
       - uses: actions/checkout@master
@@ -22,13 +25,13 @@ jobs:
       - run: rustup default 1.36.0
         shell: "bash -l {0}"
 
-      - run: cargo test --features psl -- --test-threads=8
+      - run: cargo test --features 'psl ${{ matrix.features }}' -- --test-threads=8
         shell: "bash -l {0}"
         env:
           RUST_BACKTRACE: 1
           RUST_LOG: isahc=debug
 
-      - run: cargo run --release --example simple
+      - run: cargo run --features 'psl ${{ matrix.features }}' --release --example simple
         shell: "bash -l {0}"
         env:
           RUST_BACKTRACE: 1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,10 +18,11 @@ all-features = true
 status = "actively-developed"
 
 [features]
-default = ["cookies", "http2", "static-curl"]
+default = ["cookies", "http2", "static-curl", "curl/mesalink"]
 cookies = ["chrono"]
 http2 = ["curl/http2"]
 json = ["serde", "serde_json"]
+mesalink = ["curl/mesalink", "curl-sys/mesalink"]
 nightly = []
 psl = ["parking_lot", "publicsuffix"]
 static-curl = ["curl/static-curl"]
@@ -30,8 +31,6 @@ middleware-api = []
 [dependencies]
 bytes = "0.4"
 crossbeam-channel = "0.3"
-curl = "^0.4.20"
-curl-sys = "^0.4.20"
 futures-io-preview = "=0.3.0-alpha.17"
 http = "0.1"
 lazy_static = "1"
@@ -42,6 +41,16 @@ sluice = "0.4"
 [dependencies.chrono]
 version = "0.4"
 optional = true
+
+[dependencies.curl]
+version = "^0.4.20"
+git = "https://github.com/sagebind/curl-rust"
+branch = "mesalink-ssl"
+
+[dependencies.curl-sys]
+version = "^0.4.20"
+git = "https://github.com/sagebind/curl-rust"
+branch = "mesalink-ssl"
 
 [dependencies.futures-util-preview]
 version = "=0.3.0-alpha.17"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 status = "actively-developed"
 
 [features]
-default = ["cookies", "http2", "static-curl", "curl/mesalink"]
+default = ["cookies", "http2", "static-curl"]
 cookies = ["chrono"]
 http2 = ["curl/http2"]
 json = ["serde", "serde_json"]

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -2,13 +2,11 @@ use isahc::prelude::*;
 
 fn main() -> Result<(), isahc::Error> {
     let client = HttpClient::new();
-    let mut response = client.get("http://example.org")?;
+    let mut response = client.get("https://example.org")?;
 
     println!("Status: {}", response.status());
     println!("Headers:\n{:?}", response.headers());
 
-    // Copy the response body directly to stdout.
-    // std::io::copy(response.body_mut(), &mut std::io::stdout())?;
     print!("{}", response.text()?);
 
     Ok(())

--- a/examples/ssl.rs
+++ b/examples/ssl.rs
@@ -1,0 +1,24 @@
+//! This example demonstrates HTTPS support, and also demonstrates various
+//! errors that are produced when encountering insecure connections.
+
+macro_rules! assert_matches {
+    ($e:expr, $expected:pat) => {
+        match $e {
+            $expected => (),
+            actual => panic!("expected '{}' to match pattern '{}', instead got '{:?}'", stringify!($e), stringify!($expected), actual),
+        }
+    };
+}
+
+fn main() -> Result<(), isahc::Error> {
+    env_logger::init();
+
+    assert_matches!(isahc::get("https://expired.badssl.com"), Err(isahc::Error::BadServerCertificate(_)));
+    assert_matches!(isahc::get("https://wrong.host.badssl.com"), Err(isahc::Error::SSLConnectFailed(_)));
+    assert_matches!(isahc::get("https://self-signed.badssl.com"), Err(isahc::Error::SSLConnectFailed(_)));
+    assert_matches!(isahc::get("https://untrusted-root.badssl.com"), Err(isahc::Error::SSLConnectFailed(_)));
+    assert_matches!(isahc::get("https://revoked.badssl.com"), Err(isahc::Error::SSLConnectFailed(_)));
+    assert_matches!(isahc::get("https://pinning-test.badssl.com"), Err(isahc::Error::SSLConnectFailed(_)));
+
+    Ok(())
+}


### PR DESCRIPTION
Add a new crate feature, `mesalink`, which is passed to the `curl` crate to enable using MesaLink as libcurl's chosen TLS backend.

Currently work-in-progress, as we want to wait until the necessary patches are published upstream first.

Fixes #22.