### PR TITLE
Add the ability to ignore SSL validation

### DIFF
--- a/benchmarks/benches/download.rs
+++ b/benchmarks/benches/download.rs
@@ -2,7 +2,7 @@
 
 use criterion::*;
 use isahc_benchmarks::TestServer;
-use std::io::{Write, sink};
+use std::io::{sink, Write};
 
 static DATA: [u8; 0x10000] = [1; 0x10000]; // 64K
 
@@ -43,10 +43,7 @@ fn benchmark(c: &mut Criterion) {
         b.iter_batched(
             || isahc::HttpClient::new().unwrap(),
             |client| {
-                client.get(&endpoint)
-                    .unwrap()
-                    .copy_to(sink())
-                    .unwrap();
+                client.get(&endpoint).unwrap().copy_to(sink()).unwrap();
             },
             BatchSize::SmallInput,
         )

--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,7 +1,7 @@
 use rouille::{Request, Response};
 use std::net::SocketAddr;
-use std::thread;
 use std::sync::Arc;
+use std::thread;
 
 pub struct TestServer {
     addr: SocketAddr,

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,10 +1,8 @@
 use isahc::prelude::*;
 
 fn main() -> Result<(), isahc::Error> {
-    let client = HttpClient::builder()
-        .danger_allow_unsafe_ssl(true)
-        .build()?;
-    let mut response = client.get("https://www.iep.utm.edu/desert/")?;
+    let client = HttpClient::new()?;
+    let mut response = client.get("http://example.org")?;
 
     println!("Status: {}", response.status());
     println!("Headers:\n{:?}", response.headers());

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,8 +1,10 @@
 use isahc::prelude::*;
 
 fn main() -> Result<(), isahc::Error> {
-    let client = HttpClient::new()?;
-    let mut response = client.get("http://example.org")?;
+    let client = HttpClient::builder()
+        .danger_allow_unsafe_ssl(true)
+        .build()?;
+    let mut response = client.get("https://www.iep.utm.edu/desert/")?;
 
     println!("Status: {}", response.status());
     println!("Headers:\n{:?}", response.headers());

--- a/src/client.rs
+++ b/src/client.rs
@@ -232,8 +232,8 @@ impl HttpClientBuilder {
     /// will be trusted for use. This includes expired certificates. This
     /// introduces significant vulnerabilities, and should only be used
     /// as a last resort.
-    pub fn danger_allow_unsafe_ssl(mut self, no_verify: bool) -> Self {
-        self.defaults.insert(AllowUnsafeSSL(no_verify));
+    pub fn danger_allow_unsafe_ssl(mut self, allow_unsafe: bool) -> Self {
+        self.defaults.insert(AllowUnsafeSSL(allow_unsafe));
         self
     }
 
@@ -729,8 +729,8 @@ impl HttpClient {
 
         if let Some(AllowUnsafeSSL(allow_unsafe_ssl)) = extension!(parts.extensions, self.defaults)
         {
-            easy.ssl_verify_peer(*allow_unsafe_ssl)?;
-            easy.ssl_verify_host(*allow_unsafe_ssl)?;
+            easy.ssl_verify_peer(!*allow_unsafe_ssl)?;
+            easy.ssl_verify_host(!*allow_unsafe_ssl)?;
         }
 
         // Enable automatic response decoding, unless overridden by the user via

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,9 @@ pub(crate) struct MaxDownloadSpeed(pub(crate) u64);
 #[derive(Clone, Debug)]
 pub(crate) struct DnsServers(pub(crate) Vec<SocketAddr>);
 
+#[derive(Clone, Debug)]
+pub(crate) struct AllowUnsafeSSL(pub(crate) bool);
+
 impl FromIterator<SocketAddr> for DnsServers {
     fn from_iter<I: IntoIterator<Item = SocketAddr>>(iter: I) -> Self {
         DnsServers(Vec::from_iter(iter))

--- a/src/cookies/psl/mod.rs
+++ b/src/cookies/psl/mod.rs
@@ -116,7 +116,9 @@ pub(crate) fn is_public_suffix(domain: impl AsRef<str>) -> bool {
 
     with_cache(|cache| {
         // Check if the given domain is a public suffix.
-        cache.list.parse_domain(domain)
+        cache
+            .list
+            .parse_domain(domain)
             .ok()
             .and_then(|d| d.suffix().map(|d| d == domain))
             .unwrap_or(false)

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -168,7 +168,11 @@ impl RequestHandler {
     fn complete(&mut self, result: Result<http::response::Builder, Error>) {
         if let Some(sender) = self.sender.take() {
             if let Err(e) = result.as_ref() {
-                log::warn!("request completed with error [id={:?}]: {}", self.shared.id, e);
+                log::warn!(
+                    "request completed with error [id={:?}]: {}",
+                    self.shared.id,
+                    e
+                );
             }
 
             match sender.send(result) {
@@ -377,7 +381,10 @@ impl RequestHandlerFuture {
         }
     }
 
-    fn complete(&mut self, mut builder: http::response::Builder) -> Result<Response<ResponseBodyReader>, Error> {
+    fn complete(
+        &mut self,
+        mut builder: http::response::Builder,
+    ) -> Result<Response<ResponseBodyReader>, Error> {
         let body = ResponseBodyReader {
             // Since we only take the reader here, we are allowed to panic
             // if someone tries to poll us again after the end of this call.
@@ -451,7 +458,11 @@ impl ResponseBodyReader {
 }
 
 impl AsyncRead for ResponseBodyReader {
-    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut [u8]) -> Poll<io::Result<usize>> {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut [u8],
+    ) -> Poll<io::Result<usize>> {
         let inner = &mut self.inner;
         pin_mut!(inner);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@
     rust_2018_idioms,
     unreachable_pub,
     unused,
-    clippy::all,
+    clippy::all
 )]
 
 use http::{Request, Response};
@@ -180,13 +180,7 @@ pub use http;
 
 /// A "prelude" for importing common Isahc types.
 pub mod prelude {
-    pub use crate::{
-        Body,
-        HttpClient,
-        RequestExt,
-        RequestBuilderExt,
-        ResponseExt,
-    };
+    pub use crate::{Body, HttpClient, RequestBuilderExt, RequestExt, ResponseExt};
 
     pub use http::{Request, Response};
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -147,6 +147,18 @@ pub trait RequestBuilderExt {
     /// # Ok::<(), isahc::Error>(())
     /// ```
     fn ssl_client_certificate(&mut self, certificate: ClientCertificate) -> &mut Self;
+    /// Controls the use of certificate validation.
+    ///
+    /// Defaults to `false` as per libcurl's default
+    ///
+    /// # Warning
+    ///
+    /// You should think very carefully before using this method. If
+    /// invalid certificates are trusted, *any* certificate for *any* site
+    /// will be trusted for use. This includes expired certificates. This
+    /// introduces significant vulnerabilities, and should only be used
+    /// as a last resort.
+    fn danger_allow_unsafe_ssl(&mut self, no_verify: bool) -> &mut Self;
 }
 
 impl RequestBuilderExt for http::request::Builder {
@@ -200,6 +212,9 @@ impl RequestBuilderExt for http::request::Builder {
 
     fn ssl_client_certificate(&mut self, certificate: ClientCertificate) -> &mut Self {
         self.extension(certificate)
+    }
+    fn danger_allow_unsafe_ssl(&mut self, no_verify: bool) -> &mut Self {
+        self.extension(AllowUnsafeSSL(no_verify))
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -213,8 +213,8 @@ impl RequestBuilderExt for http::request::Builder {
     fn ssl_client_certificate(&mut self, certificate: ClientCertificate) -> &mut Self {
         self.extension(certificate)
     }
-    fn danger_allow_unsafe_ssl(&mut self, no_verify: bool) -> &mut Self {
-        self.extension(AllowUnsafeSSL(no_verify))
+    fn danger_allow_unsafe_ssl(&mut self, allow_unsafe: bool) -> &mut Self {
+        self.extension(AllowUnsafeSSL(allow_unsafe))
     }
 }
 

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -1,5 +1,5 @@
-use flate2::Compression;
 use flate2::read::{DeflateEncoder, GzEncoder};
+use flate2::Compression;
 use isahc::prelude::*;
 use mockito::{mock, server_url};
 use std::io::Read;

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,4 +1,4 @@
-use mockito::{Matcher, mock, server_url};
+use mockito::{mock, server_url, Matcher};
 
 speculate::speculate! {
     before {


### PR DESCRIPTION
Reqwest has a config option to disregard SSL validation. This PR enables that functionality in isahc. It is a feature I need for my own crate, where I just need to verify that the links are accessible, even if unsafe. Sometimes, libcurl will report as unsafe while a browser will say it's fine, for example https://www.iep.utm.edu/desert/

I also ran `cargo fmt`, resulting in some amount of reformatting elsewhere.