### PR TITLE
Fix auto referer not setting referer header

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1,23 +1,27 @@
 //! The HTTP client implementation.
 
-use crate::agent;
-use crate::config::*;
-use crate::handler::{RequestHandler, RequestHandlerFuture, ResponseBodyReader};
-use crate::middleware::Middleware;
-use crate::{Body, Error};
+use crate::{
+    agent,
+    config::*,
+    handler::{RequestHandler, RequestHandlerFuture, ResponseBodyReader},
+    middleware::Middleware,
+    Body, Error,
+};
 use futures_io::AsyncRead;
 use futures_util::pin_mut;
 use http::{Request, Response};
 use lazy_static::lazy_static;
-use std::fmt;
-use std::future::Future;
-use std::io;
-use std::iter::FromIterator;
-use std::net::SocketAddr;
-use std::pin::Pin;
-use std::sync::Arc;
-use std::task::{Context, Poll};
-use std::time::Duration;
+use std::{
+    fmt,
+    future::Future,
+    io,
+    iter::FromIterator,
+    net::SocketAddr,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+    time::Duration,
+};
 
 lazy_static! {
     static ref USER_AGENT: String = format!(
@@ -233,7 +237,7 @@ impl HttpClientBuilder {
     /// introduces significant vulnerabilities, and should only be used
     /// as a last resort.
     pub fn danger_allow_unsafe_ssl(mut self, allow_unsafe: bool) -> Self {
-        self.defaults.insert(AllowUnsafeSSL(allow_unsafe));
+        self.defaults.insert(AllowUnsafeSsl(allow_unsafe));
         self
     }
 
@@ -638,100 +642,43 @@ impl HttpClient {
         let body_length = body.len();
         let (handler, future) = RequestHandler::new(body);
 
-        // Helper for fetching an extension first from the request, then falling
-        // back to client defaults.
-        macro_rules! extension {
-            ($first:expr) => {
-                $first.get()
-            };
-
-            ($first:expr, $($rest:expr),+) => {
-                $first.get().or_else(|| extension!($($rest),*))
-            };
-        }
-
         let mut easy = curl::easy::Easy2::new(handler);
 
         easy.verbose(log::log_enabled!(log::Level::Debug))?;
         easy.signal(false)?;
 
-        if let Some(Timeout(timeout)) = extension!(parts.extensions, self.defaults) {
-            easy.timeout(*timeout)?;
+        // Macro to apply all config values given in the request or in defaults.
+        macro_rules! set_opts {
+            ($easy:expr, $extensions:expr, $defaults:expr, [$($option:ty,)*]) => {{
+                $(
+                    if let Some(extension) = $extensions.get::<$option>().or_else(|| $defaults.get()) {
+                        extension.set_opt($easy)?;
+                    }
+                )*
+            }};
         }
 
-        if let Some(ConnectTimeout(timeout)) = extension!(parts.extensions, self.defaults) {
-            easy.connect_timeout(*timeout)?;
-        }
-
-        if let Some(TcpKeepAlive(interval)) = extension!(parts.extensions, self.defaults) {
-            easy.tcp_keepalive(true)?;
-            easy.tcp_keepintvl(*interval)?;
-        }
-
-        if let Some(TcpNoDelay) = extension!(parts.extensions, self.defaults) {
-            easy.tcp_nodelay(true)?;
-        }
-
-        if let Some(redirect_policy) = extension!(parts.extensions, self.defaults) {
-            match redirect_policy {
-                RedirectPolicy::Follow => {
-                    easy.follow_location(true)?;
-                }
-                RedirectPolicy::Limit(max) => {
-                    easy.follow_location(true)?;
-                    easy.max_redirections(*max)?;
-                }
-                RedirectPolicy::None => {
-                    easy.follow_location(false)?;
-                }
-            }
-        }
-
-        if let Some(MaxUploadSpeed(limit)) = extension!(parts.extensions, self.defaults) {
-            easy.max_send_speed(*limit)?;
-        }
-
-        if let Some(MaxDownloadSpeed(limit)) = extension!(parts.extensions, self.defaults) {
-            easy.max_recv_speed(*limit)?;
-        }
-
-        // Set a preferred HTTP version to negotiate.
-        easy.http_version(match extension!(parts.extensions, self.defaults) {
-            Some(PreferredHttpVersion(http::Version::HTTP_10)) => curl::easy::HttpVersion::V10,
-            Some(PreferredHttpVersion(http::Version::HTTP_11)) => curl::easy::HttpVersion::V11,
-            Some(PreferredHttpVersion(http::Version::HTTP_2)) => curl::easy::HttpVersion::V2,
-            _ => curl::easy::HttpVersion::Any,
-        })?;
-
-        if let Some(Proxy(proxy)) = extension!(parts.extensions, self.defaults) {
-            easy.proxy(&format!("{}", proxy))?;
-        }
-
-        if let Some(DnsServers(addrs)) = extension!(parts.extensions, self.defaults) {
-            let dns_string = addrs
-                .iter()
-                .map(ToString::to_string)
-                .collect::<Vec<_>>()
-                .join(",");
-            if let Err(e) = easy.dns_servers(&dns_string) {
-                log::warn!("DNS servers could not be configured: {}", e);
-            }
-        }
-
-        // Configure SSL options.
-        if let Some(SslCiphers(ciphers)) = extension!(parts.extensions, self.defaults) {
-            easy.ssl_cipher_list(&ciphers.join(":"))?;
-        }
-
-        if let Some(cert) = extension!(parts.extensions, self.defaults) {
-            easy.ssl_client_certificate(cert)?;
-        }
-
-        if let Some(AllowUnsafeSSL(allow_unsafe_ssl)) = extension!(parts.extensions, self.defaults)
-        {
-            easy.ssl_verify_peer(!*allow_unsafe_ssl)?;
-            easy.ssl_verify_host(!*allow_unsafe_ssl)?;
-        }
+        set_opts!(
+            &mut easy,
+            parts.extensions,
+            self.defaults,
+            [
+                Timeout,
+                ConnectTimeout,
+                TcpKeepAlive,
+                TcpNoDelay,
+                RedirectPolicy,
+                AutoReferer,
+                MaxUploadSpeed,
+                MaxDownloadSpeed,
+                PreferredHttpVersion,
+                Proxy,
+                DnsServers,
+                SslCiphers,
+                ClientCertificate,
+                AllowUnsafeSsl,
+            ]
+        );
 
         // Enable automatic response decoding, unless overridden by the user via
         // a custom Accept-Encoding value.
@@ -819,66 +766,6 @@ impl HttpClient {
 impl fmt::Debug for HttpClient {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("HttpClient").finish()
-    }
-}
-
-/// Helper extension methods for curl easy handles.
-trait EasyExt {
-    fn easy(&mut self) -> &mut curl::easy::Easy2<RequestHandler>;
-
-    fn ssl_client_certificate(&mut self, cert: &ClientCertificate) -> Result<(), curl::Error> {
-        match cert {
-            ClientCertificate::PEM { path, private_key } => {
-                self.easy().ssl_cert(path)?;
-                self.easy().ssl_cert_type("PEM")?;
-                if let Some(key) = private_key {
-                    self.ssl_private_key(key)?;
-                }
-            }
-            ClientCertificate::DER { path, private_key } => {
-                self.easy().ssl_cert(path)?;
-                self.easy().ssl_cert_type("DER")?;
-                if let Some(key) = private_key {
-                    self.ssl_private_key(key)?;
-                }
-            }
-            ClientCertificate::P12 { path, password } => {
-                self.easy().ssl_cert(path)?;
-                self.easy().ssl_cert_type("P12")?;
-                if let Some(password) = password {
-                    self.easy().key_password(password)?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-
-    fn ssl_private_key(&mut self, key: &PrivateKey) -> Result<(), curl::Error> {
-        match key {
-            PrivateKey::PEM { path, password } => {
-                self.easy().ssl_key(path)?;
-                self.easy().ssl_key_type("PEM")?;
-                if let Some(password) = password {
-                    self.easy().key_password(password)?;
-                }
-            }
-            PrivateKey::DER { path, password } => {
-                self.easy().ssl_key(path)?;
-                self.easy().ssl_key_type("DER")?;
-                if let Some(password) = password {
-                    self.easy().key_password(password)?;
-                }
-            }
-        }
-
-        Ok(())
-    }
-}
-
-impl EasyExt for curl::easy::Easy2<RequestHandler> {
-    fn easy(&mut self) -> &mut Self {
-        self
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -8,6 +8,12 @@ use std::net::SocketAddr;
 use std::path::PathBuf;
 use std::time::Duration;
 
+/// A helper trait for applying a configuration value to a given curl handle.
+pub(crate) trait SetOpt {
+    /// Apply this configuration option to the given curl handle.
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error>;
+}
+
 /// Describes a policy for handling server redirects.
 ///
 /// The default is to not follow redirects.
@@ -27,6 +33,25 @@ pub enum RedirectPolicy {
 impl Default for RedirectPolicy {
     fn default() -> Self {
         RedirectPolicy::None
+    }
+}
+
+impl SetOpt for RedirectPolicy {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        match self {
+            RedirectPolicy::Follow => {
+                easy.follow_location(true)?;
+            }
+            RedirectPolicy::Limit(max) => {
+                easy.follow_location(true)?;
+                easy.max_redirections(*max)?;
+            }
+            RedirectPolicy::None => {
+                easy.follow_location(false)?;
+            }
+        }
+
+        Ok(())
     }
 }
 
@@ -59,6 +84,36 @@ pub enum ClientCertificate {
     },
 }
 
+impl SetOpt for ClientCertificate {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        match self {
+            ClientCertificate::PEM { path, private_key } => {
+                easy.ssl_cert(path)?;
+                easy.ssl_cert_type("PEM")?;
+                if let Some(key) = private_key {
+                    key.set_opt(easy)?;
+                }
+            }
+            ClientCertificate::DER { path, private_key } => {
+                easy.ssl_cert(path)?;
+                easy.ssl_cert_type("DER")?;
+                if let Some(key) = private_key {
+                    key.set_opt(easy)?;
+                }
+            }
+            ClientCertificate::P12 { path, password } => {
+                easy.ssl_cert(path)?;
+                easy.ssl_cert_type("P12")?;
+                if let Some(password) = password {
+                    easy.key_password(password)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 /// A private key file.
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum PrivateKey {
@@ -80,35 +135,109 @@ pub enum PrivateKey {
     },
 }
 
+impl SetOpt for PrivateKey {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        match self {
+            PrivateKey::PEM { path, password } => {
+                easy.ssl_key(path)?;
+                easy.ssl_key_type("PEM")?;
+                if let Some(password) = password {
+                    easy.key_password(password)?;
+                }
+            }
+            PrivateKey::DER { path, password } => {
+                easy.ssl_key(path)?;
+                easy.ssl_key_type("DER")?;
+                if let Some(password) = password {
+                    easy.key_password(password)?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct Timeout(pub(crate) Duration);
+
+impl SetOpt for Timeout {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.timeout(self.0)
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct ConnectTimeout(pub(crate) Duration);
 
+impl SetOpt for ConnectTimeout {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.connect_timeout(self.0)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct TcpKeepAlive(pub(crate) Duration);
+
+impl SetOpt for TcpKeepAlive {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.tcp_keepalive(true)?;
+        easy.tcp_keepintvl(self.0)
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct PreferredHttpVersion(pub(crate) http::Version);
 
+impl SetOpt for PreferredHttpVersion {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.http_version(match self.0 {
+            http::Version::HTTP_10 => curl::easy::HttpVersion::V10,
+            http::Version::HTTP_11 => curl::easy::HttpVersion::V11,
+            http::Version::HTTP_2 => curl::easy::HttpVersion::V2,
+            _ => curl::easy::HttpVersion::Any,
+        })
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct TcpNoDelay;
+
+impl SetOpt for TcpNoDelay {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.tcp_nodelay(true)
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct AutoReferer;
 
+impl SetOpt for AutoReferer {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.autoreferer(true)
+    }
+}
+
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct MaxUploadSpeed(pub(crate) u64);
+
+impl SetOpt for MaxUploadSpeed {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.max_send_speed(self.0)
+    }
+}
 
 #[derive(Clone, Copy, Debug)]
 pub(crate) struct MaxDownloadSpeed(pub(crate) u64);
 
-#[derive(Clone, Debug)]
-pub(crate) struct DnsServers(pub(crate) Vec<SocketAddr>);
+impl SetOpt for MaxDownloadSpeed {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.max_recv_speed(self.0)
+    }
+}
 
 #[derive(Clone, Debug)]
-pub(crate) struct AllowUnsafeSSL(pub(crate) bool);
+pub(crate) struct DnsServers(pub(crate) Vec<SocketAddr>);
 
 impl FromIterator<SocketAddr> for DnsServers {
     fn from_iter<I: IntoIterator<Item = SocketAddr>>(iter: I) -> Self {
@@ -116,8 +245,31 @@ impl FromIterator<SocketAddr> for DnsServers {
     }
 }
 
+impl SetOpt for DnsServers {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        let dns_string = self.0
+            .iter()
+            .map(ToString::to_string)
+            .collect::<Vec<_>>()
+            .join(",");
+
+        // DNS servers should not be hard error.
+        if let Err(e) = easy.dns_servers(&dns_string) {
+            log::warn!("DNS servers could not be configured: {}", e);
+        }
+
+        Ok(())
+    }
+}
+
 #[derive(Clone, Debug)]
 pub(crate) struct Proxy(pub(crate) http::Uri);
+
+impl SetOpt for Proxy {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.proxy(&format!("{}", self.0))
+    }
+}
 
 #[derive(Clone, Debug)]
 pub(crate) struct SslCiphers(pub(crate) Vec<String>);
@@ -125,5 +277,21 @@ pub(crate) struct SslCiphers(pub(crate) Vec<String>);
 impl FromIterator<String> for SslCiphers {
     fn from_iter<I: IntoIterator<Item = String>>(iter: I) -> Self {
         SslCiphers(Vec::from_iter(iter))
+    }
+}
+
+impl SetOpt for SslCiphers {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.ssl_cipher_list(&self.0.join(":"))
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct AllowUnsafeSsl(pub(crate) bool);
+
+impl SetOpt for AllowUnsafeSsl {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.ssl_verify_peer(!self.0)?;
+        easy.ssl_verify_host(!self.0)
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -214,7 +214,7 @@ impl RequestBuilderExt for http::request::Builder {
         self.extension(certificate)
     }
     fn danger_allow_unsafe_ssl(&mut self, allow_unsafe: bool) -> &mut Self {
-        self.extension(AllowUnsafeSSL(allow_unsafe))
+        self.extension(AllowUnsafeSsl(allow_unsafe))
     }
 }
 

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -124,4 +124,33 @@ speculate::speculate! {
         m1.expect(3);
         m2.expect(3);
     }
+
+    test "auto referer sets expected header" {
+        let m1 = mock("GET", "/a")
+            .with_status(301)
+            .with_header("Location", "/b")
+            .create();
+
+        let m2 = mock("GET", "/b")
+            .with_status(301)
+            .with_header("Location", "/c")
+            .match_header("Referer", (server_url() + "/a").as_str())
+            .create();
+
+        let m3 = mock("GET", "/c")
+            .match_header("Referer", (server_url() + "/b").as_str())
+            .create();
+
+        Request::get(server_url() + "/a")
+            .redirect_policy(RedirectPolicy::Follow)
+            .auto_referer()
+            .body(())
+            .unwrap()
+            .send()
+            .unwrap();
+
+        m1.assert();
+        m2.assert();
+        m3.assert();
+    }
 }


### PR DESCRIPTION
Fix auto referer option not being respected on outgoing headers. Add a test to make sure it is working.

Also refactor how configuration options are applied to curl easy handles to make the code a little more manageable and easier to understand.