### PR TITLE
Add options for configuring the connection cache

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -143,7 +143,7 @@ impl HttpClientBuilder {
     /// chosen.
     pub fn connection_cache_size(mut self, size: usize) -> Self {
         self.agent_builder = self.agent_builder.connection_cache_size(size);
-        self.defaults.insert(DisableConnectionCache(size == 0));
+        self.defaults.insert(CloseConnection(size == 0));
         self
     }
 
@@ -738,7 +738,7 @@ impl HttpClient {
                 SslCiphers,
                 ClientCertificate,
                 AllowUnsafeSsl,
-                DisableConnectionCache,
+                CloseConnection,
             ]
         );
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -738,6 +738,7 @@ impl HttpClient {
                 SslCiphers,
                 ClientCertificate,
                 AllowUnsafeSsl,
+                DisableConnectionCache,
             ]
         );
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -130,6 +130,23 @@ impl HttpClientBuilder {
         self
     }
 
+    /// Set the size of the connection cache.
+    ///
+    /// After requests are completed, if the underlying connection is reusable,
+    /// it is added to the connection cache to be reused to reduce latency for
+    /// future requests.
+    ///
+    /// Setting the size to `0` disables connection caching for all requests
+    /// using this client.
+    ///
+    /// By default this value is unspecified. A reasonable default size will be
+    /// chosen.
+    pub fn connection_cache_size(mut self, size: usize) -> Self {
+        self.agent_builder = self.agent_builder.connection_cache_size(size);
+        self.defaults.insert(DisableConnectionCache(size == 0));
+        self
+    }
+
     /// Set a timeout for the maximum time allowed for a request-response cycle.
     ///
     /// If not set, no timeout will be enforced.

--- a/src/config.rs
+++ b/src/config.rs
@@ -295,3 +295,13 @@ impl SetOpt for AllowUnsafeSsl {
         easy.ssl_verify_host(!self.0)
     }
 }
+
+#[derive(Clone, Debug)]
+pub(crate) struct DisableConnectionCache(pub(crate) bool);
+
+impl SetOpt for DisableConnectionCache {
+    fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
+        easy.fresh_connect(self.0)?;
+        easy.forbid_reuse(self.0)
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -296,12 +296,13 @@ impl SetOpt for AllowUnsafeSsl {
     }
 }
 
+/// Close the connection when the request completes instead of returning it to
+/// the connection cache.
 #[derive(Clone, Debug)]
-pub(crate) struct DisableConnectionCache(pub(crate) bool);
+pub(crate) struct CloseConnection(pub(crate) bool);
 
-impl SetOpt for DisableConnectionCache {
+impl SetOpt for CloseConnection {
     fn set_opt<H>(&self, easy: &mut curl::easy::Easy2<H>) -> Result<(), curl::Error> {
-        easy.fresh_connect(self.0)?;
         easy.forbid_reuse(self.0)
     }
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -147,6 +147,7 @@ pub trait RequestBuilderExt {
     /// # Ok::<(), isahc::Error>(())
     /// ```
     fn ssl_client_certificate(&mut self, certificate: ClientCertificate) -> &mut Self;
+
     /// Controls the use of certificate validation.
     ///
     /// Defaults to `false` as per libcurl's default
@@ -159,6 +160,14 @@ pub trait RequestBuilderExt {
     /// introduces significant vulnerabilities, and should only be used
     /// as a last resort.
     fn danger_allow_unsafe_ssl(&mut self, no_verify: bool) -> &mut Self;
+
+    /// Disable connection reuse for this request.
+    ///
+    /// By default, requests re-use persistent open connections available to the
+    /// same host in a connection cache (unless disabled by the client). Calling
+    /// this will ensure a new connection will be established for this request
+    /// that will not be partake in the connection cache.
+    fn disable_connection_cache(&mut self) -> &mut Self;
 }
 
 impl RequestBuilderExt for http::request::Builder {
@@ -213,8 +222,13 @@ impl RequestBuilderExt for http::request::Builder {
     fn ssl_client_certificate(&mut self, certificate: ClientCertificate) -> &mut Self {
         self.extension(certificate)
     }
+
     fn danger_allow_unsafe_ssl(&mut self, allow_unsafe: bool) -> &mut Self {
         self.extension(AllowUnsafeSsl(allow_unsafe))
+    }
+
+    fn disable_connection_cache(&mut self) -> &mut Self {
+        self.extension(DisableConnectionCache(true))
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -160,14 +160,6 @@ pub trait RequestBuilderExt {
     /// introduces significant vulnerabilities, and should only be used
     /// as a last resort.
     fn danger_allow_unsafe_ssl(&mut self, no_verify: bool) -> &mut Self;
-
-    /// Disable connection reuse for this request.
-    ///
-    /// By default, requests re-use persistent open connections available to the
-    /// same host in a connection cache (unless disabled by the client). Calling
-    /// this will ensure a new connection will be established for this request
-    /// that will not be partake in the connection cache.
-    fn disable_connection_cache(&mut self) -> &mut Self;
 }
 
 impl RequestBuilderExt for http::request::Builder {
@@ -225,10 +217,6 @@ impl RequestBuilderExt for http::request::Builder {
 
     fn danger_allow_unsafe_ssl(&mut self, allow_unsafe: bool) -> &mut Self {
         self.extension(AllowUnsafeSsl(allow_unsafe))
-    }
-
-    fn disable_connection_cache(&mut self) -> &mut Self {
-        self.extension(DisableConnectionCache(true))
     }
 }
 


### PR DESCRIPTION
There are good use cases why you might want to limit the size of the connection cache, or disable it altogether.

Add `connection_cache_size` to `HttpClientBuilder`, which allows you to override the defaults and set a maximum number of persistent connections to keep in the cache, or to disable connection caching altogether.

Fixes part of #79.