### PR TITLE
Keep all instances of the same response header

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -269,7 +269,7 @@ impl curl::easy::Handler for RequestHandler {
 
         // Is this a header line?
         if let Some((name, value)) = parse::parse_header(data) {
-            self.response_headers.insert(name, value);
+            self.response_headers.append(name, value);
             return true;
         }
 


### PR DESCRIPTION
I was playing around with surf and was wondering why I could only get one of multiple `set-cookie` headers... turns out `HeaderMap::insert` overrides any existing value(s) for the given key.