### PR TITLE
Add new VersionNegotiation API

### DIFF
--- a/examples/http2.rs
+++ b/examples/http2.rs
@@ -1,8 +1,9 @@
+use isahc::config::VersionNegotiation;
 use isahc::prelude::*;
 
 fn main() -> Result<(), isahc::Error> {
     let response = Request::get("https://nghttp2.org")
-        .preferred_http_version(isahc::http::Version::HTTP_2)
+        .version_negotiation(VersionNegotiation::http2())
         .body(())
         .map_err(Into::into)
         .and_then(isahc::send)?;

--- a/src/request.rs
+++ b/src/request.rs
@@ -38,6 +38,12 @@ pub trait RequestBuilderExt {
     /// If not set, a connect timeout of 300 seconds will be used.
     fn connect_timeout(&mut self, timeout: Duration) -> &mut Self;
 
+    /// Configure how the use of HTTP versions should be negotiated with the
+    /// server.
+    ///
+    /// The default is [`HttpVersionNegotiation::latest_compatible`].
+    fn version_negotiation(&mut self, negotiation: VersionNegotiation) -> &mut Self;
+
     /// Set a policy for automatically following server redirects.
     ///
     /// The default is to not follow redirects.
@@ -80,13 +86,6 @@ pub trait RequestBuilderExt {
     /// This setting will do nothing unless you also set one or more
     /// authentication methods using [`RequestBuilderExt::authentication`].
     fn credentials(&mut self, credentials: Credentials) -> &mut Self;
-
-    /// Set a preferred HTTP version the client should attempt to use to
-    /// communicate to the server with.
-    ///
-    /// This is treated as a suggestion. A different version may be used if the
-    /// server does not support it or negotiates a different version.
-    fn preferred_http_version(&mut self, version: http::Version) -> &mut Self;
 
     /// Enable TCP keepalive with a given probe interval.
     fn tcp_keepalive(&mut self, interval: Duration) -> &mut Self;
@@ -231,6 +230,10 @@ impl RequestBuilderExt for http::request::Builder {
         self.extension(ConnectTimeout(timeout))
     }
 
+    fn version_negotiation(&mut self, negotiation: VersionNegotiation) -> &mut Self {
+        self.extension(negotiation)
+    }
+
     fn redirect_policy(&mut self, policy: RedirectPolicy) -> &mut Self {
         self.extension(policy)
     }
@@ -245,10 +248,6 @@ impl RequestBuilderExt for http::request::Builder {
 
     fn credentials(&mut self, credentials: Credentials) -> &mut Self {
         self.extension(credentials)
-    }
-
-    fn preferred_http_version(&mut self, version: http::Version) -> &mut Self {
-        self.extension(PreferredHttpVersion(version))
     }
 
     fn tcp_keepalive(&mut self, interval: Duration) -> &mut Self {

--- a/tests/version.rs
+++ b/tests/version.rs
@@ -1,0 +1,24 @@
+use isahc::config::VersionNegotiation;
+use isahc::prelude::*;
+use mockito::{mock, server_url};
+
+speculate::speculate! {
+    before {
+        env_logger::try_init().ok();
+    }
+
+    test "latest compatible negotiation politely asks for HTTP/2" {
+        let m = mock("GET", "/")
+            .match_header("upgrade", "h2c")
+            .create();
+
+        Request::get(server_url())
+            .version_negotiation(VersionNegotiation::latest_compatible())
+            .body(())
+            .unwrap()
+            .send()
+            .unwrap();
+
+        m.assert();
+    }
+}


### PR DESCRIPTION
Replace `preferred_http_version()` with a new `VersionNegotiation` API that provides more explicit and clear settings for how HTTP versions will be negotiated. This also provides support for "HTTP/2 Prior Knowledge", and will allow us to support HTTP/3 when it comes in the future in a backwards-compatible way.

This is implemented almost exactly as proposed in #108.

Fixes #108.