### PR TITLE
use 'default-feature = false' on futures-util

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,7 @@ optional = true
 
 [dependencies.futures-util]
 version = "0.3"
+default-features = false
 features = ["io"]
 
 [dependencies.parking_lot]


### PR DESCRIPTION
once https://github.com/sagebind/sluice/pull/7 is merged isahc will no longer depend on the `syn` crate, which should improve compile times and drops the dependency count from 41 to 34