### PR TITLE
Breaking API changes to Body

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -641,9 +641,9 @@ impl HttpClient {
             };
 
             if let Some(len) = content_length {
-                Body::reader_sized(body, len)
+                Body::from_reader_sized(body, len)
             } else {
-                Body::reader(body)
+                Body::from_reader(body)
             }
         });
 

--- a/tests/request_body.rs
+++ b/tests/request_body.rs
@@ -43,7 +43,7 @@ speculate::speculate! {
                 .uri(server_url())
                 // This header should be ignored
                 .header("transfer-encoding", "identity")
-                .body(Body::reader(body.as_bytes()))
+                .body(Body::from_reader(body.as_bytes()))
                 .unwrap()
                 .send()
                 .unwrap();

--- a/tests/response_body.rs
+++ b/tests/response_body.rs
@@ -1,3 +1,4 @@
+use isahc::prelude::*;
 use mockito::{mock, server_url};
 
 speculate::speculate! {
@@ -11,7 +12,7 @@ speculate::speculate! {
             .create();
 
         let mut response = isahc::get(server_url()).unwrap();
-        let response_text = response.body_mut().text().unwrap();
+        let response_text = response.text().unwrap();
 
         assert_eq!(response_text, "hello world");
         m.assert();
@@ -25,7 +26,7 @@ speculate::speculate! {
             .create();
 
         let mut response = isahc::get(server_url()).unwrap();
-        let response_text = response.body_mut().text().unwrap();
+        let response_text = response.text().unwrap();
 
         assert_eq!(response_text, body);
         m.assert();
@@ -64,7 +65,7 @@ speculate::speculate! {
         let mut response = client.get(server_url()).unwrap();
         drop(client);
 
-        assert_eq!(response.body_mut().text().unwrap().len(), body.len());
+        assert_eq!(response.text().unwrap().len(), body.len());
         m.assert();
     }
 


### PR DESCRIPTION
- Prefix constructor-like functions with `from_` for consistency.
- Remove text-related methods (fixes #142).
- Remove `Bytes` from public API for more stability.