### PR TITLE
Migrate from log to tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,6 @@ futures-channel = "0.3"
 futures-io = "0.3"
 http = "0.2"
 lazy_static = "1"
-log = "0.4"
 slab = "0.4"
 sluice = "0.5"
 
@@ -76,6 +75,15 @@ optional = true
 version = "1.0"
 optional = true
 
+[dependencies.tracing]
+version = "0.1"
+features = ["log"]
+
+[dependencies.tracing-futures]
+version = "0.2"
+default-features = false
+features = ["std", "std-future"]
+
 [dev-dependencies]
 env_logger = "0.7"
 flate2 = "1.0"
@@ -86,6 +94,7 @@ rayon = "1"
 speculate = "0.1"
 static_assertions = "1.1"
 structopt = "0.3"
+tracing-subscriber = "0.2"
 
 [[example]]
 name = "json"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ futures-channel = "0.3"
 futures-io = "0.3"
 http = "0.2"
 lazy_static = "1"
+log = "0.4"
 slab = "0.4"
 sluice = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -76,7 +76,7 @@ version = "1.0"
 optional = true
 
 [dependencies.tracing]
-version = "0.1"
+version = "0.1.14"
 features = ["log"]
 
 [dependencies.tracing-futures]

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -21,7 +21,6 @@ use std::task::Waker;
 use std::thread;
 use std::time::{Duration, Instant};
 
-const AGENT_THREAD_NAME: &str = "curl agent";
 const WAIT_TIMEOUT: Duration = Duration::from_millis(100);
 
 type EasyHandle = curl::easy::Easy2<RequestHandler>;
@@ -60,8 +59,9 @@ impl AgentBuilder {
         let wake_socket = UdpSocket::bind("127.0.0.1:0")?;
         wake_socket.set_nonblocking(true)?;
         let wake_addr = wake_socket.local_addr()?;
+        let id = wake_addr.port();
         let waker = futures_util::task::waker(Arc::new(UdpWaker::connect(wake_addr)?));
-        log::debug!("agent waker listening on {}", wake_addr);
+        tracing::debug!("agent waker listening on {}", wake_addr);
 
         let (message_tx, message_rx) = crossbeam_channel::unbounded();
 
@@ -72,48 +72,57 @@ impl AgentBuilder {
         let max_connections_per_host = self.max_connections_per_host;
         let connection_cache_size = self.connection_cache_size;
 
+        // Create a span for the agent thread that outlives this method call,
+        // but rather was caused by it.
+        let agent_span = tracing::trace_span!("agent_thread", id);
+        agent_span.follows_from(tracing::Span::current());
+
         let handle = Handle {
             message_tx: message_tx.clone(),
             waker: waker.clone(),
             join_handle: Mutex::new(Some(
                 thread::Builder::new()
-                    .name(AGENT_THREAD_NAME.into())
+                    .name(format!("isahc-agent-{}", id))
                     .spawn(move || {
-                        let mut multi = curl::multi::Multi::new();
+                        agent_span.in_scope(|| {
+                            let mut multi = curl::multi::Multi::new();
 
-                        if max_connections > 0 {
-                            multi.set_max_total_connections(max_connections)?;
-                        }
+                            if max_connections > 0 {
+                                multi.set_max_total_connections(max_connections)?;
+                            }
 
-                        if max_connections_per_host > 0 {
-                            multi.set_max_host_connections(max_connections_per_host)?;
-                        }
+                            if max_connections_per_host > 0 {
+                                multi.set_max_host_connections(max_connections_per_host)?;
+                            }
 
-                        // Only set maxconnects if greater than 0, because 0 actually means unlimited.
-                        if connection_cache_size > 0 {
-                            multi.set_max_connects(connection_cache_size)?;
-                        }
+                            // Only set maxconnects if greater than 0, because 0 actually means unlimited.
+                            if connection_cache_size > 0 {
+                                multi.set_max_connects(connection_cache_size)?;
+                            }
 
-                        let agent = AgentContext {
-                            multi,
-                            multi_messages: crossbeam_channel::unbounded(),
-                            message_tx,
-                            message_rx,
-                            wake_socket,
-                            requests: Slab::new(),
-                            close_requested: false,
-                            waker,
-                        };
+                            let agent = AgentContext {
+                                multi,
+                                multi_messages: crossbeam_channel::unbounded(),
+                                message_tx,
+                                message_rx,
+                                wake_socket,
+                                requests: Slab::new(),
+                                close_requested: false,
+                                waker,
+                            };
 
-                        drop(wait_group_thread);
-                        log::debug!("agent took {:?} to start up", create_start.elapsed());
+                            drop(wait_group_thread);
 
-                        let result = agent.run();
-                        if let Err(e) = &result {
-                            log::error!("agent shut down with error: {}", e);
-                        }
+                            tracing::debug!("agent took {:?} to start up", create_start.elapsed());
 
-                        result
+                            let result = agent.run();
+
+                            if let Err(e) = &result {
+                                tracing::error!("agent shut down with error: {}", e);
+                            }
+
+                            result
+                        })
                     })?,
             )),
         };
@@ -241,20 +250,21 @@ impl Drop for Handle {
     fn drop(&mut self) {
         // Request the agent thread to shut down.
         if self.send_message(Message::Close).is_err() {
-            log::error!("agent thread terminated prematurely");
+            tracing::error!("agent thread terminated prematurely");
         }
 
         // Wait for the agent thread to shut down before continuing.
         match self.try_join() {
-            JoinResult::Ok => log::trace!("agent thread joined cleanly"),
-            JoinResult::Err(e) => log::error!("agent thread terminated with error: {}", e),
-            JoinResult::Panic => log::error!("agent thread panicked"),
+            JoinResult::Ok => tracing::trace!("agent thread joined cleanly"),
+            JoinResult::Err(e) => tracing::error!("agent thread terminated with error: {}", e),
+            JoinResult::Panic => tracing::error!("agent thread panicked"),
             _ => {}
         }
     }
 }
 
 impl AgentContext {
+    #[tracing::instrument(level = "trace", skip(self))]
     fn begin_request(&mut self, mut request: EasyHandle) -> Result<(), Error> {
         // Prepare an entry for storing this request while it executes.
         let entry = self.requests.vacant_entry();
@@ -271,7 +281,7 @@ impl AgentContext {
                 self.waker
                     .chain(move |inner| match tx.send(Message::UnpauseRead(id)) {
                         Ok(()) => inner.wake_by_ref(),
-                        Err(_) => log::warn!(
+                        Err(_) => tracing::warn!(
                             "agent went away while resuming read for request [id={}]",
                             id
                         ),
@@ -283,7 +293,7 @@ impl AgentContext {
                 self.waker
                     .chain(move |inner| match tx.send(Message::UnpauseWrite(id)) {
                         Ok(()) => inner.wake_by_ref(),
-                        Err(_) => log::warn!(
+                        Err(_) => tracing::warn!(
                             "agent went away while resuming write for request [id={}]",
                             id
                         ),
@@ -301,6 +311,7 @@ impl AgentContext {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn complete_request(
         &mut self,
         token: usize,
@@ -338,13 +349,14 @@ impl AgentContext {
     ///
     /// If there are no active requests right now, this function will block
     /// until a message is received.
+    #[tracing::instrument(level = "trace", skip(self))]
     fn poll_messages(&mut self) -> Result<(), Error> {
         while !self.close_requested {
             if self.requests.is_empty() {
                 match self.message_rx.recv() {
                     Ok(message) => self.handle_message(message)?,
                     _ => {
-                        log::warn!("agent handle disconnected without close message");
+                        tracing::warn!("agent handle disconnected without close message");
                         self.close_requested = true;
                         break;
                     }
@@ -354,7 +366,7 @@ impl AgentContext {
                     Ok(message) => self.handle_message(message)?,
                     Err(crossbeam_channel::TryRecvError::Empty) => break,
                     Err(crossbeam_channel::TryRecvError::Disconnected) => {
-                        log::warn!("agent handle disconnected without close message");
+                        tracing::warn!("agent handle disconnected without close message");
                         self.close_requested = true;
                         break;
                     }
@@ -365,8 +377,9 @@ impl AgentContext {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn handle_message(&mut self, message: Message) -> Result<(), Error> {
-        log::trace!("received message from agent handle: {:?}", message);
+        tracing::trace!("received message from agent handle");
 
         match message {
             Message::Close => self.close_requested = true,
@@ -381,10 +394,10 @@ impl AgentContext {
                         // the transfer alive until it errors through the normal
                         // means, which is likely to happen this turn of the
                         // event loop anyway.
-                        log::debug!("error unpausing read for request [id={}]: {}", token, e);
+                        tracing::debug!("error unpausing read for request [id={}]: {}", token, e);
                     }
                 } else {
-                    log::warn!(
+                    tracing::warn!(
                         "received unpause request for unknown request token: {}",
                         token
                     );
@@ -400,10 +413,10 @@ impl AgentContext {
                         // the transfer alive until it errors through the normal
                         // means, which is likely to happen this turn of the
                         // event loop anyway.
-                        log::debug!("error unpausing write for request [id={}]: {}", token, e);
+                        tracing::debug!("error unpausing write for request [id={}]: {}", token, e);
                     }
                 } else {
-                    log::warn!(
+                    tracing::warn!(
                         "received unpause request for unknown request token: {}",
                         token
                     );
@@ -414,6 +427,7 @@ impl AgentContext {
         Ok(())
     }
 
+    #[tracing::instrument(level = "trace", skip(self))]
     fn dispatch(&mut self) -> Result<(), Error> {
         self.multi.perform()?;
 
@@ -446,7 +460,7 @@ impl AgentContext {
 
         debug_assert_eq!(wait_fds.len(), 1);
 
-        log::debug!("agent ready");
+        tracing::debug!("agent ready");
 
         // Agent main loop.
         loop {
@@ -465,7 +479,7 @@ impl AgentContext {
             // We might have woken up early from the notify fd, so drain the
             // socket to clear it.
             if wait_fds[0].received_read() {
-                log::trace!("woke up from waker");
+                tracing::trace!("woke up from waker");
 
                 // Read data out of the wake socket to clean the buffer. While
                 // it's possible that there's a lot of data in the buffer, it
@@ -475,7 +489,7 @@ impl AgentContext {
             }
         }
 
-        log::debug!("agent shutting down");
+        tracing::debug!("agent shutting down");
 
         self.requests.clear();
         self.multi.close()?;

--- a/src/client.rs
+++ b/src/client.rs
@@ -874,7 +874,7 @@ impl HttpClient {
         let mut easy = curl::easy::Easy2::new(handler);
 
         // Set whether curl should generate verbose debug data for us to log.
-        easy.verbose(dbg!(easy.get_ref().is_debug_enabled()))?;
+        easy.verbose(easy.get_ref().is_debug_enabled())?;
 
         easy.signal(false)?;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -27,6 +27,7 @@ use std::{
     sync::Arc,
     task::{Context, Poll},
 };
+use tracing_futures::Instrument;
 
 lazy_static! {
     static ref USER_AGENT: String = format!(
@@ -368,6 +369,7 @@ impl HttpClientBuilder {
     /// Build an [`HttpClient`] using the configured options.
     ///
     /// If the client fails to initialize, an error will be returned.
+    #[tracing::instrument(skip(self))]
     pub fn build(self) -> Result<HttpClient, Error> {
         if let Some(err) = self.error {
             return Err(err);
@@ -500,6 +502,7 @@ impl HttpClient {
     /// Create a new HTTP client using the default configuration.
     ///
     /// If the client fails to initialize, an error will be returned.
+    #[tracing::instrument]
     pub fn new() -> Result<Self, Error> {
         HttpClientBuilder::default().build()
     }
@@ -507,6 +510,7 @@ impl HttpClient {
     /// Get a reference to a global client instance.
     ///
     /// TODO: Stabilize.
+    #[tracing::instrument]
     pub(crate) fn shared() -> &'static Self {
         lazy_static! {
             static ref SHARED: HttpClient =
@@ -744,6 +748,7 @@ impl HttpClient {
     /// # Ok::<(), isahc::Error>(())
     /// ```
     #[inline]
+    #[tracing::instrument(skip(self, request))]
     pub fn send<B: Into<Body>>(&self, request: Request<B>) -> Result<Response<Body>, Error> {
         self.send_async(request).join()
     }
@@ -772,9 +777,16 @@ impl HttpClient {
     /// # Ok(()) }
     /// ```
     pub fn send_async<B: Into<Body>>(&self, request: Request<B>) -> ResponseFuture<'_> {
-        let request = request.map(Into::into);
+        tracing::info_span!(
+            "send_async",
+            method = ?request.method(),
+            uri = ?request.uri(),
+        )
+        .in_scope(move || {
+            let request = request.map(Into::into);
 
-        ResponseFuture::new(self.send_async_inner(request))
+            ResponseFuture::new(self.send_async_inner(request).in_current_span())
+        })
     }
 
     fn send_builder_async(
@@ -782,7 +794,9 @@ impl HttpClient {
         builder: http::request::Builder,
         body: Body,
     ) -> ResponseFuture<'_> {
-        ResponseFuture::new(async move { self.send_async_inner(builder.body(body)?).await })
+        ResponseFuture::new(
+            async move { self.send_async_inner(builder.body(body)?).await }.in_current_span(),
+        )
     }
 
     /// Actually send the request. All the public methods go through here.
@@ -840,7 +854,6 @@ impl HttpClient {
         Ok(response)
     }
 
-    #[allow(clippy::cognitive_complexity)]
     fn create_easy_handle(
         &self,
         request: Request<Body>,
@@ -859,7 +872,9 @@ impl HttpClient {
 
         let mut easy = curl::easy::Easy2::new(handler);
 
-        easy.verbose(log::log_enabled!(log::Level::Debug))?;
+        // easy.verbose(log::log_enabled!(log::Level::Debug))?;
+        // easy.verbose(!tracing::debug_span!("verbose").is_disabled())?;
+        easy.verbose(true)?;
         easy.signal(false)?;
 
         // Macro to apply all config values given in the request or in defaults.

--- a/src/config/dns.rs
+++ b/src/config/dns.rs
@@ -116,7 +116,7 @@ impl SetOpt for Servers {
     fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
         // DNS servers should not be hard error.
         if let Err(e) = easy.dns_servers(&self.0) {
-            log::warn!("DNS servers could not be configured: {}", e);
+            tracing::warn!("DNS servers could not be configured: {}", e);
         }
 
         Ok(())

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -581,7 +581,7 @@ impl SetOpt for VersionNegotiation {
             if self.strict {
                 return Err(e);
             } else {
-                log::debug!("failed to set HTTP version: {}", e);
+                tracing::debug!("failed to set HTTP version: {}", e);
             }
         }
 

--- a/src/cookies/mod.rs
+++ b/src/cookies/mod.rs
@@ -91,7 +91,7 @@ impl Cookie {
             // The given domain must domain-match the origin.
             // https://tools.ietf.org/html/rfc6265#section-5.3.6
             if !Cookie::domain_matches(uri.host()?, domain) {
-                log::warn!(
+                tracing::warn!(
                     "cookie '{}' dropped, domain '{}' not allowed to set cookies for '{}'",
                     cookie_name,
                     uri.host()?,
@@ -102,7 +102,7 @@ impl Cookie {
 
             // Drop cookies for top-level domains.
             if !domain.contains('.') {
-                log::warn!(
+                tracing::warn!(
                     "cookie '{}' dropped, setting cookies for domain '{}' is not allowed",
                     cookie_name,
                     domain
@@ -115,7 +115,7 @@ impl Cookie {
             #[cfg(feature = "psl")]
             {
                 if psl::is_public_suffix(domain) {
-                    log::warn!(
+                    tracing::warn!(
                         "cookie '{}' dropped, setting cookies for domain '{}' is not allowed",
                         cookie_name,
                         domain
@@ -285,7 +285,7 @@ impl Middleware for CookieJar {
                 .into_iter()
                 .filter_map(|header| {
                     header.to_str().ok().or_else(|| {
-                        log::warn!("invalid encoding in Set-Cookie header");
+                        tracing::warn!("invalid encoding in Set-Cookie header");
                         None
                     })
                 })
@@ -294,7 +294,7 @@ impl Middleware for CookieJar {
                         .effective_uri()
                         .and_then(|uri| Cookie::parse(header, uri))
                         .or_else(|| {
-                            log::warn!("could not parse Set-Cookie header");
+                            tracing::warn!("could not parse Set-Cookie header");
                             None
                         })
                 });

--- a/src/cookies/psl/mod.rs
+++ b/src/cookies/psl/mod.rs
@@ -89,7 +89,7 @@ impl ListCache {
                 // Parse the suffix list.
                 self.list = List::from_reader(response.body_mut())?;
                 self.last_updated = Some(Utc::now());
-                log::debug!("public suffix list updated");
+                tracing::debug!("public suffix list updated");
             }
 
             http::StatusCode::NOT_MODIFIED => {
@@ -97,7 +97,7 @@ impl ListCache {
                 self.last_updated = Some(Utc::now());
             }
 
-            status => log::warn!(
+            status => tracing::warn!(
                 "could not update public suffix list, got status code {}",
                 status,
             ),
@@ -139,7 +139,7 @@ fn with_cache<T>(f: impl FnOnce(&ListCache) -> T) -> T {
         // more.
         if cache.needs_refreshed() {
             if let Err(e) = cache.refresh() {
-                log::warn!("could not refresh public suffix list: {}", e);
+                tracing::warn!("could not refresh public suffix list: {}", e);
             }
         }
 

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -92,10 +92,6 @@ unsafe impl Send for RequestHandler {}
 /// This is also used to keep track of the lifetime of the request.
 #[derive(Debug)]
 struct Shared {
-    /// The ID of the request that this handler is managing. Assigned by the
-    /// request agent.
-    id: AtomicCell<usize>,
-
     /// A waker used by the handler to wake up the associated future.
     waker: AtomicWaker,
 
@@ -113,7 +109,6 @@ impl RequestHandler {
     ) {
         let (sender, receiver) = futures_channel::oneshot::channel();
         let shared = Arc::new(Shared {
-            id: AtomicCell::new(usize::max_value()),
             waker: AtomicWaker::default(),
             completed: AtomicCell::new(false),
             response_body_dropped: AtomicCell::new(false),
@@ -121,7 +116,7 @@ impl RequestHandler {
         let (response_body_reader, response_body_writer) = pipe::pipe();
 
         let handler = Self {
-            span: tracing::trace_span!("handler", id = tracing::field::Empty),
+            span: tracing::debug_span!("handler", id = tracing::field::Empty),
             sender: Some(sender),
             shared: shared.clone(),
             request_body,
@@ -151,6 +146,24 @@ impl RequestHandler {
         (handler, future)
     }
 
+    /// Check whether debug info should be generated. This function is used to
+    /// determine whether to set the `verbose` curl option to true.
+    pub(crate) fn is_debug_enabled(&self) -> bool {
+        // To avoid having curl generate debug strings unnecessarily, we want to
+        // enable debug info only if:
+        //
+        // - a tracing subscriber is set and is interested in the current span,
+        // - or a logger is set that is enabled at debug or higher.
+        //
+        // This logic seems a little screwy when comparing to what the docs say,
+        // but it works.
+        if self.span.is_none() {
+            false
+        } else {
+            log::log_enabled!(log::Level::Debug)
+        }
+    }
+
     fn is_future_canceled(&self) -> bool {
         self.sender
             .as_ref()
@@ -173,11 +186,9 @@ impl RequestHandler {
         let _enter = self.span.enter();
 
         // Init should not be called more than once.
-        debug_assert!(self.shared.id.load() == usize::max_value());
         debug_assert!(self.request_body_waker.is_none());
         debug_assert!(self.response_body_waker.is_none());
 
-        self.shared.id.store(id);
         self.span.record("id", &id);
         self.handle = handle;
         self.request_body_waker = Some(request_waker);
@@ -186,17 +197,18 @@ impl RequestHandler {
 
     /// Handle a result produced by curl for this handler's current transfer.
     pub(crate) fn on_result(&mut self, result: Result<(), curl::Error>) {
-        tracing::trace_span!(parent: &self.span, "on_result").in_scope(move || {
-            self.shared.completed.store(true);
+        let span = tracing::trace_span!(parent: &self.span, "on_result");
+        let _enter = span.enter();
 
-            match result {
-                Ok(()) => self.flush_response_headers(),
-                Err(e) => {
-                    tracing::debug!("curl error: {}", e);
-                    self.complete(Err(e.into()));
-                }
+        self.shared.completed.store(true);
+
+        match result {
+            Ok(()) => self.flush_response_headers(),
+            Err(e) => {
+                tracing::debug!("curl error: {}", e);
+                self.complete(Err(e.into()));
             }
-        })
+        }
     }
 
     /// Mark the future as completed successfully with the response headers
@@ -233,26 +245,23 @@ impl RequestHandler {
 
     /// Complete the associated future with a result.
     fn complete(&mut self, result: Result<http::response::Builder, Error>) {
-        tracing::trace_span!(parent: &self.span, "complete").in_scope(move || {
-            if let Some(sender) = self.sender.take() {
-                if let Err(e) = result.as_ref() {
-                    tracing::warn!(
-                        "request completed with error [id={:?}]: {}",
-                        self.shared.id,
-                        e
-                    );
-                }
+        let span = tracing::trace_span!(parent: &self.span, "complete");
+        let _enter = span.enter();
 
-                match sender.send(result) {
-                    Ok(()) => {
-                        self.shared.waker.wake();
-                    }
-                    Err(_) => {
-                        tracing::debug!("request canceled by user [id={:?}]", self.shared.id);
-                    }
+        if let Some(sender) = self.sender.take() {
+            if let Err(e) = result.as_ref() {
+                tracing::warn!("request completed with error: {}", e);
+            }
+
+            match sender.send(result) {
+                Ok(()) => {
+                    self.shared.waker.wake();
+                }
+                Err(_) => {
+                    tracing::debug!("request canceled by user");
                 }
             }
-        })
+        }
     }
 
     #[allow(unsafe_code)]
@@ -285,46 +294,47 @@ impl curl::easy::Handler for RequestHandler {
             return false;
         }
 
-        tracing::trace_span!(parent: &self.span, "header").in_scope(move || {
-            // Curl calls this function for all lines in the response not part of
-            // the response body, not just for headers. We need to inspect the
-            // contents of the string in order to determine what it is and how to
-            // parse it, just as if we were reading from the socket of a HTTP/1.0 or
-            // HTTP/1.1 connection ourselves.
+        let span = tracing::trace_span!(parent: &self.span, "header");
+        let _enter = span.enter();
 
-            // Is this the status line?
-            if let Some((version, status)) = parse::parse_status_line(data) {
-                self.response_version = Some(version);
-                self.response_status_code = Some(status);
+        // Curl calls this function for all lines in the response not part of
+        // the response body, not just for headers. We need to inspect the
+        // contents of the string in order to determine what it is and how to
+        // parse it, just as if we were reading from the socket of a HTTP/1.0 or
+        // HTTP/1.1 connection ourselves.
 
-                // Also clear any pre-existing headers that might be left over from
-                // a previous intermediate response.
-                self.response_headers.clear();
+        // Is this the status line?
+        if let Some((version, status)) = parse::parse_status_line(data) {
+            self.response_version = Some(version);
+            self.response_status_code = Some(status);
 
-                return true;
-            }
+            // Also clear any pre-existing headers that might be left over from
+            // a previous intermediate response.
+            self.response_headers.clear();
 
-            // Is this a header line?
-            if let Some((name, value)) = parse::parse_header(data) {
-                self.response_headers.append(name, value);
-                return true;
-            }
+            return true;
+        }
 
-            // Is this the end of the response header?
-            if data == b"\r\n" {
-                // We will acknowledge the end of the header, but we can't complete
-                // our response future yet. If curl decides to follow a redirect,
-                // then this current response is not the final response and not the
-                // one we should complete with.
-                //
-                // Instead, we will complete the future when curl marks the transfer
-                // as complete, or when we start receiving a response body.
-                return true;
-            }
+        // Is this a header line?
+        if let Some((name, value)) = parse::parse_header(data) {
+            self.response_headers.append(name, value);
+            return true;
+        }
 
-            // Unknown header line we don't know how to parse.
-            false
-        })
+        // Is this the end of the response header?
+        if data == b"\r\n" {
+            // We will acknowledge the end of the header, but we can't complete
+            // our response future yet. If curl decides to follow a redirect,
+            // then this current response is not the final response and not the
+            // one we should complete with.
+            //
+            // Instead, we will complete the future when curl marks the transfer
+            // as complete, or when we start receiving a response body.
+            return true;
+        }
+
+        // Unknown header line we don't know how to parse.
+        false
     }
 
     /// Gets called by curl when attempting to send bytes of the request body.
@@ -334,26 +344,27 @@ impl curl::easy::Handler for RequestHandler {
             return Err(ReadError::Abort);
         }
 
-        tracing::trace_span!(parent: &self.span, "read").in_scope(move || {
-            // Create a task context using a waker provided by the agent so we can
-            // do an asynchronous read.
-            if let Some(waker) = self.request_body_waker.as_ref() {
-                let mut context = Context::from_waker(waker);
+        let span = tracing::trace_span!(parent: &self.span, "read");
+        let _enter = span.enter();
 
-                match Pin::new(&mut self.request_body).poll_read(&mut context, data) {
-                    Poll::Pending => Err(ReadError::Pause),
-                    Poll::Ready(Ok(len)) => Ok(len),
-                    Poll::Ready(Err(e)) => {
-                        tracing::error!("error reading request body: {}", e);
-                        Err(ReadError::Abort)
-                    }
+        // Create a task context using a waker provided by the agent so we can
+        // do an asynchronous read.
+        if let Some(waker) = self.request_body_waker.as_ref() {
+            let mut context = Context::from_waker(waker);
+
+            match Pin::new(&mut self.request_body).poll_read(&mut context, data) {
+                Poll::Pending => Err(ReadError::Pause),
+                Poll::Ready(Ok(len)) => Ok(len),
+                Poll::Ready(Err(e)) => {
+                    tracing::error!("error reading request body: {}", e);
+                    Err(ReadError::Abort)
                 }
-            } else {
-                // The request should never be started without calling init first.
-                tracing::error!("request has not been initialized!");
-                Err(ReadError::Abort)
             }
-        })
+        } else {
+            // The request should never be started without calling init first.
+            tracing::error!("request has not been initialized!");
+            Err(ReadError::Abort)
+        }
     }
 
     /// Gets called by curl when it wants to seek to a certain position in the
@@ -363,58 +374,57 @@ impl curl::easy::Handler for RequestHandler {
     /// seek, we can't do any async operations in this callback. That's why we
     /// only support trivial types of seeking.
     fn seek(&mut self, whence: io::SeekFrom) -> SeekResult {
-        tracing::trace_span!(parent: &self.span, "seek", whence = ?whence).in_scope(move || {
-            // If curl wants to seek to the beginning, there's a chance that we
-            // can do that.
-            if whence == io::SeekFrom::Start(0) && self.request_body.reset() {
-                SeekResult::Ok
-            } else {
-                tracing::warn!("seek requested for request body, but it is not supported");
-                // We can't do any other type of seek, sorry :(
-                SeekResult::CantSeek
-            }
-        })
+        let span = tracing::trace_span!(parent: &self.span, "seek", whence = ?whence);
+        let _enter = span.enter();
+
+        // If curl wants to seek to the beginning, there's a chance that we
+        // can do that.
+        if whence == io::SeekFrom::Start(0) && self.request_body.reset() {
+            SeekResult::Ok
+        } else {
+            tracing::warn!("seek requested for request body, but it is not supported");
+            // We can't do any other type of seek, sorry :(
+            SeekResult::CantSeek
+        }
     }
 
     /// Gets called by curl when bytes from the response body are received.
     fn write(&mut self, data: &[u8]) -> Result<usize, WriteError> {
-        tracing::trace_span!(parent: &self.span, "write").in_scope(move || {
-            tracing::trace!("received {} bytes of data", data.len());
+        let span = tracing::trace_span!(parent: &self.span, "write");
+        let _enter = span.enter();
+        tracing::trace!("received {} bytes of data", data.len());
 
-            // Abort the request if it has been canceled.
-            if self.shared.response_body_dropped.load() {
-                return Ok(0);
-            }
+        // Abort the request if it has been canceled.
+        if self.shared.response_body_dropped.load() {
+            return Ok(0);
+        }
 
-            // Now that we've started receiving the response body, we know no more
-            // redirects can happen and we can complete the future safely.
-            self.flush_response_headers();
+        // Now that we've started receiving the response body, we know no more
+        // redirects can happen and we can complete the future safely.
+        self.flush_response_headers();
 
-            // Create a task context using a waker provided by the agent so we can
-            // do an asynchronous write.
-            if let Some(waker) = self.response_body_waker.as_ref() {
-                let mut context = Context::from_waker(waker);
+        // Create a task context using a waker provided by the agent so we can
+        // do an asynchronous write.
+        if let Some(waker) = self.response_body_waker.as_ref() {
+            let mut context = Context::from_waker(waker);
 
-                match Pin::new(&mut self.response_body_writer).poll_write(&mut context, data) {
-                    Poll::Pending => Err(WriteError::Pause),
-                    Poll::Ready(Ok(len)) => Ok(len),
-                    Poll::Ready(Err(e)) => {
-                        if e.kind() == io::ErrorKind::BrokenPipe {
-                            tracing::warn!(
-                            "failed to write response body because the response reader was dropped"
-                        );
-                        } else {
-                            tracing::error!("error writing response body to buffer: {}", e);
-                        }
-                        Ok(0)
+            match Pin::new(&mut self.response_body_writer).poll_write(&mut context, data) {
+                Poll::Pending => Err(WriteError::Pause),
+                Poll::Ready(Ok(len)) => Ok(len),
+                Poll::Ready(Err(e)) => {
+                    if e.kind() == io::ErrorKind::BrokenPipe {
+                        tracing::warn!("failed to write response body because the response reader was dropped");
+                    } else {
+                        tracing::error!("error writing response body to buffer: {}", e);
                     }
+                    Ok(0)
                 }
-            } else {
-                // The request should never be started without calling init first.
-                tracing::error!("request has not been initialized!");
-                Ok(0)
             }
-        })
+        } else {
+            // The request should never be started without calling init first.
+            tracing::error!("request has not been initialized!");
+            Ok(0)
+        }
     }
 
     /// Capture transfer progress updates from curl.
@@ -511,7 +521,7 @@ impl curl::easy::Handler for RequestHandler {
 
         match kind {
             InfoType::Text => {
-                tracing::debug!(target: "isahc::curl", "{}", String::from_utf8_lossy(data).trim_end())
+                tracing::debug!("{}", String::from_utf8_lossy(data).trim_end())
             }
             InfoType::HeaderIn | InfoType::DataIn => {
                 tracing::trace!(target: "isahc::wire", "<< {}", FormatAscii(data))
@@ -526,7 +536,7 @@ impl curl::easy::Handler for RequestHandler {
 
 impl fmt::Debug for RequestHandler {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "RequestHandler({:?})", self.shared.id)
+        write!(f, "RequestHandler")
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -212,6 +212,9 @@
     unused,
     clippy::all
 )]
+// This lint produces a lot of false positives. See
+// https://github.com/rust-lang/rust-clippy/issues/3900.
+#![allow(clippy::cognitive_complexity)]
 
 use http::{Request, Response};
 use lazy_static::lazy_static;

--- a/src/task.rs
+++ b/src/task.rs
@@ -94,7 +94,7 @@ impl ArcWake for UdpWaker {
         // We don't actually care here if this succeeds. Maybe the agent is
         // busy, or tired, or just needs some alone time right now.
         if let Err(e) = arc_self.socket.send(&[1]) {
-            log::debug!("agent waker produced an error: {}", e);
+            tracing::debug!("agent waker produced an error: {}", e);
         }
     }
 }

--- a/src/text.rs
+++ b/src/text.rs
@@ -96,7 +96,7 @@ impl Decoder {
                 {
                     return Self::new(encoding);
                 } else {
-                    log::warn!("unknown encoding '{}', falling back to UTF-8", charset);
+                    tracing::warn!("unknown encoding '{}', falling back to UTF-8", charset);
                 }
             }
         }


### PR DESCRIPTION
Emit all logs as `tracing` events, with backward compatability with log records.

Fixes #77.