### PR TITLE
Added static-ssl feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,13 +18,14 @@ features = ["cookies", "json"]
 status = "actively-developed"
 
 [features]
-default = ["http2", "static-curl", "text-decoding"]
+default = ["http2", "static-curl", "static-ssl", "text-decoding"]
 cookies = ["chrono"]
 http2 = ["curl/http2"]
 json = ["serde", "serde_json"]
 psl = ["parking_lot", "publicsuffix"]
 spnego = ["curl-sys/spnego"]
 static-curl = ["curl/static-curl"]
+static-ssl = ["curl/static-ssl"]
 text-decoding = ["encoding_rs", "mime"]
 middleware-api-preview = []
 


### PR DESCRIPTION
Sometimes openssl is not available in the environments, and would be great to use a static version of it.

Thankfully, Curl rust already supports that via the `static-ssl` flag.

This PR adds support for it in `isahc` as well :)