### PR TITLE
Fix code coverage runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,11 +54,12 @@ jobs:
           args: --features cookies,psl --no-fail-fast
         env:
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          CARGO_PROFILE_test_PANIC: abort
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
 
       - name: Install grcov
         run: |
-          curl -LSs https://github.com/mozilla/grcov/releases/download/v0.5.9/grcov-linux-x86_64.tar.bz2 | sudo tar xjf - -C /usr/local/bin
+          curl -LSs https://github.com/mozilla/grcov/releases/download/v0.5.13/grcov-linux-x86_64.tar.bz2 | sudo tar xjf - -C /usr/local/bin
 
       - uses: actions-rs/grcov@v0.1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,7 @@ jobs:
           args: --features cookies,psl --no-fail-fast
         env:
           CARGO_INCREMENTAL: '0'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zno-landing-pads'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
 
       - name: Install grcov
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
         with:
           args: "--features cookies,psl"
 
-      - uses: codecov/codecov-action@v1
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          fail_ci_if_error: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,8 +54,12 @@ jobs:
           args: --features cookies,psl --no-fail-fast
         env:
           CARGO_INCREMENTAL: '0'
-          CARGO_PROFILE_test_PANIC: abort
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Zpanic_abort_tests'
+          # CARGO_PROFILE_dev_OVERFLOW_CHECKS: 'false'
+          # CARGO_PROFILE_dev_PANIC: abort
+          # CARGO_PROFILE_test_OVERFLOW_CHECKS: 'false'
+          # CARGO_PROFILE_test_PANIC: abort
+          # RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
+          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
 
       - name: Install grcov
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,31 +43,9 @@ jobs:
         with:
           submodules: true
 
-      - uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-
-      - uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --features cookies,psl --no-fail-fast
-        env:
-          CARGO_INCREMENTAL: '0'
-          # CARGO_PROFILE_dev_OVERFLOW_CHECKS: 'false'
-          # CARGO_PROFILE_dev_PANIC: abort
-          # CARGO_PROFILE_test_OVERFLOW_CHECKS: 'false'
-          # CARGO_PROFILE_test_PANIC: abort
-          # RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off -Cpanic=abort -Zpanic_abort_tests'
-          RUSTFLAGS: '-Zprofile -Ccodegen-units=1 -Cinline-threshold=0 -Clink-dead-code -Coverflow-checks=off'
-
-      - name: Install grcov
-        run: |
-          curl -LSs https://github.com/mozilla/grcov/releases/download/v0.5.13/grcov-linux-x86_64.tar.bz2 | sudo tar xjf - -C /usr/local/bin
-
-      - uses: actions-rs/grcov@v0.1
+      - name: Generate code coverage report
+        uses: actions-rs/tarpaulin@v0.1
 
       - uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          file: ./lcov.info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,8 @@ jobs:
 
       - name: Generate code coverage report
         uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: "--features cookies,psl"
 
       - uses: codecov/codecov-action@v1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@
 target
 Cargo.lock
 *.code-workspace
+
+# Code coverage reports
+cobertura.xml


### PR DESCRIPTION
`-Zno-landing-pads` was removed from nightly recently (https://github.com/rust-lang/rust/pull/70175), which seems to mess up grcov reports (https://github.com/mozilla/grcov/issues/427). Even after figuring out how to set `panic=abort` on all the correct profiles, it seems that it still reports odd numbers relative to when `-Zno-landing-pads` worked.

Switch to [tarpaulin](https://github.com/xd009642/tarpaulin) for now which has also caught my eye recently.