### PR TITLE
Replace default_headers_mut with default_headers

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -493,7 +493,7 @@ pub struct HttpClient {
     /// Any middleware implementations that requests should pass through.
     middleware: Vec<Box<dyn Middleware>>,
     /// Default headers to add to every request.
-    default_headers: http::HeaderMap<HeaderValue>,
+    default_headers: HeaderMap<HeaderValue>,
 }
 
 impl HttpClient {

--- a/src/client.rs
+++ b/src/client.rs
@@ -19,7 +19,7 @@ use http::{
 };
 use lazy_static::lazy_static;
 use std::{
-    convert::{TryFrom, TryInto},
+    convert::TryFrom,
     fmt,
     future::Future,
     io,

--- a/src/error.rs
+++ b/src/error.rs
@@ -92,6 +92,13 @@ impl StdError for Error {
 }
 
 #[doc(hidden)]
+impl From<std::convert::Infallible> for Error {
+    fn from(error: std::convert::Infallible) -> Error {
+        error.into()
+    }
+}
+
+#[doc(hidden)]
 impl From<curl::Error> for Error {
     fn from(error: curl::Error) -> Error {
         if error.is_ssl_certproblem() || error.is_ssl_cacert_badfile() {

--- a/src/error.rs
+++ b/src/error.rs
@@ -155,20 +155,6 @@ impl From<http::Error> for Error {
 }
 
 #[doc(hidden)]
-impl From<http::header::InvalidHeaderName> for Error {
-    fn from(error: http::header::InvalidHeaderName) -> Error {
-        Error::InvalidHttpFormat(error.into())
-    }
-}
-
-#[doc(hidden)]
-impl From<http::header::InvalidHeaderValue> for Error {
-    fn from(error: http::header::InvalidHeaderValue) -> Error {
-        Error::InvalidHttpFormat(error.into())
-    }
-}
-
-#[doc(hidden)]
 impl From<io::Error> for Error {
     fn from(error: io::Error) -> Error {
         match error.kind() {


### PR DESCRIPTION
Thinking about future compatibility, we might want to leverage interceptors someday as an implementation detail for how default headers are set. To avoid locking us in the current implementation, do not expose the default `HeaderMap` as a direct reference. Instead, for users who want to set headers in bulk, provide `default_headers` which takes an iterator of key-value pairs and replaces all existing headers. That allows users to do the same kind of things without relying on a mutable `HeaderMap` being exposed.

Also tweak some docs.