### PR TITLE
Change all tracing spans to Trace level

### DIFF
--- a/examples/logging.rs
+++ b/examples/logging.rs
@@ -1,0 +1,14 @@
+//! Capturing log events using a [log] implementation.
+//!
+//! [log]: https://github.com/rust-lang/log
+
+fn main() -> Result<(), isahc::Error> {
+    env_logger::init();
+
+    let mut response = isahc::get("https://example.org")?;
+
+    // Consume the response stream quietly.
+    std::io::copy(response.body_mut(), &mut std::io::sink())?;
+
+    Ok(())
+}

--- a/examples/tracing.rs
+++ b/examples/tracing.rs
@@ -1,0 +1,14 @@
+//! Capturing log events using a [tracing] subscriber.
+//!
+//! [tracing]: https://github.com/tokio-rs/tracing
+
+fn main() -> Result<(), isahc::Error> {
+    tracing_subscriber::fmt::init();
+
+    let mut response = isahc::get("https://example.org")?;
+
+    // Consume the response stream quietly.
+    std::io::copy(response.body_mut(), &mut std::io::sink())?;
+
+    Ok(())
+}

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -74,7 +74,7 @@ impl AgentBuilder {
 
         // Create a span for the agent thread that outlives this method call,
         // but rather was caused by it.
-        let agent_span = tracing::debug_span!("agent_thread", port);
+        let agent_span = tracing::trace_span!("agent_thread", port);
         agent_span.follows_from(tracing::Span::current());
 
         let handle = Handle {

--- a/src/client.rs
+++ b/src/client.rs
@@ -369,7 +369,7 @@ impl HttpClientBuilder {
     /// Build an [`HttpClient`] using the configured options.
     ///
     /// If the client fails to initialize, an error will be returned.
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub fn build(self) -> Result<HttpClient, Error> {
         if let Some(err) = self.error {
             return Err(err);
@@ -502,7 +502,7 @@ impl HttpClient {
     /// Create a new HTTP client using the default configuration.
     ///
     /// If the client fails to initialize, an error will be returned.
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     pub fn new() -> Result<Self, Error> {
         HttpClientBuilder::default().build()
     }
@@ -510,7 +510,7 @@ impl HttpClient {
     /// Get a reference to a global client instance.
     ///
     /// TODO: Stabilize.
-    #[tracing::instrument]
+    #[tracing::instrument(level = "trace")]
     pub(crate) fn shared() -> &'static Self {
         lazy_static! {
             static ref SHARED: HttpClient =
@@ -748,7 +748,7 @@ impl HttpClient {
     /// # Ok::<(), isahc::Error>(())
     /// ```
     #[inline]
-    #[tracing::instrument(skip(self, request))]
+    #[tracing::instrument(level = "trace", skip(self, request))]
     pub fn send<B: Into<Body>>(&self, request: Request<B>) -> Result<Response<Body>, Error> {
         self.send_async(request).join()
     }
@@ -794,7 +794,7 @@ impl HttpClient {
 
     /// Actually send the request. All the public methods go through here.
     async fn send_async_inner(&self, mut request: Request<Body>) -> Result<Response<Body>, Error> {
-        let span = tracing::info_span!(
+        let span = tracing::trace_span!(
             "send_async",
             method = ?request.method(),
             uri = ?request.uri(),

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -116,7 +116,7 @@ impl RequestHandler {
         let (response_body_reader, response_body_writer) = pipe::pipe();
 
         let handler = Self {
-            span: tracing::debug_span!("handler", id = tracing::field::Empty),
+            span: tracing::trace_span!("handler", id = tracing::field::Empty),
             sender: Some(sender),
             shared: shared.clone(),
             request_body,
@@ -157,7 +157,7 @@ impl RequestHandler {
         //
         // This logic seems a little screwy when comparing to what the docs say,
         // but it works.
-        if self.span.is_none() {
+        if tracing::debug_span!("handler").is_none() {
             false
         } else {
             log::log_enabled!(log::Level::Debug)


### PR DESCRIPTION
This cripples the tracing subscriber ability somewhat, but tones down the noisy logs coming from the `tracing::span` target.

A better solution would be for enter/exit logs from `tracing::span` to be emitted always at the `Trace` level in the `tracing` library.

Fixes #192.