### PR TITLE
Update analysis CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,11 +46,11 @@ jobs:
       - name: Generate code coverage report
         uses: actions-rs/tarpaulin@v0.1
         with:
-          version: '0.11.1'
+          version: '0.13.3'
           args: "--run-types Doctests Tests --features cookies,psl"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
- Jump back to the latest tarpaulin version which fixed doctests https://github.com/xd009642/tarpaulin/issues/402.
- Don't fail CI if codecov fails to upload because of https://github.com/codecov/codecov-action/issues/81