### PR TITLE
Invalid read: Multi::close called twice

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -489,7 +489,6 @@ impl AgentContext {
         tracing::debug!("agent shutting down");
 
         self.requests.clear();
-        self.multi.close()?;
 
         Ok(())
     }


### PR DESCRIPTION
`Multi::close` is called a second time in the `Drop` impl: https://docs.rs/curl/0.4.29/src/curl/multi.rs.html#728-732
Valgrind reports the following:

```
==5851== Invalid read of size 8
==5851==    at 0x560D4A5: curl_multi_cleanup (in /usr/lib/libcurl.so.4.6.0)
==5851==    by 0x4E75621: curl::multi::Multi::close (multi.rs:705)
==5851==    by 0x4E756AA: <curl::multi::Multi as core::ops::drop::Drop>::drop (multi.rs:730)
==5851==    by 0x4D86E76: core::ptr::drop_in_place (mod.rs:177)
==5851==    by 0x4D87D96: core::ptr::drop_in_place (mod.rs:177)
==5851==    by 0x4DD41B3: isahc::agent::AgentContext::run (agent.rs:495)
```

Removing the call to `close` seems to fix it, however some memory leaks remain.