### PR TITLE
Don't combine nobody with upload

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -952,11 +952,9 @@ impl HttpClient {
             (&http::Method::GET, false) => {
                 easy.get(true)?;
             }
-            // HEAD requests do not wait for a response payload.
-            (&http::Method::HEAD, has_body) => {
+            // Normal HEAD request.
+            (&http::Method::HEAD, false) => {
                 easy.nobody(true)?;
-                easy.upload(has_body)?;
-                easy.custom_request("HEAD")?;
             }
             // POST requests have special redirect behavior.
             (&http::Method::POST, _) => {


### PR DESCRIPTION
Based on feedback from Stenberg himself in https://github.com/curl/curl/issues/5717, it doesn't really make much sense to set both `nobody` _and_ `upload` on the same request in order to fulfill weird HEAD requests with a request body. Change (and simplify) to use `nobody` for normal HEAD requests, and `upload` + `customrequest` otherwise.