### PR TITLE
add static-ssl feature to mirror curl/static-ssl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ json = ["serde", "serde_json"]
 psl = ["parking_lot", "publicsuffix"]
 spnego = ["curl-sys/spnego"]
 static-curl = ["curl/static-curl"]
+static-ssl = ["curl/static-ssl"]
 text-decoding = ["encoding_rs", "mime"]
 middleware-api-preview = []
 


### PR DESCRIPTION
I have some builds that I'd like to have produce a fully static binary, and for that I need to expose `curl/static-ssl`. I think for the general case having it dynamically linked is fine (I mean no one has complained thus far!), so I've left it out of the default features for now, but would be happy to add it there if you feel it's worth it.

Thanks!