### PR TITLE
Add option to disable automatic decompression

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -85,6 +85,10 @@ impl HttpClientBuilder {
         // Always start out with latest compatible HTTP version.
         defaults.insert(VersionNegotiation::default());
 
+        // Enable automatic decompression by default for convenience (and
+        // maintain backwards compatibility).
+        defaults.insert(AutomaticDecompression(true));
+
         // Erase curl's default auth method of Basic.
         defaults.insert(Authentication::default());
 
@@ -914,6 +918,7 @@ impl HttpClient {
                 Dialer,
                 RedirectPolicy,
                 redirect::AutoReferer,
+                AutomaticDecompression,
                 Authentication,
                 Credentials,
                 MaxUploadSpeed,
@@ -934,17 +939,6 @@ impl HttpClient {
                 EnableMetrics,
             ]
         );
-
-        // Enable automatic response decoding, unless overridden by the user via
-        // a custom Accept-Encoding value.
-        easy.accept_encoding(
-            parts
-                .headers
-                .get("Accept-Encoding")
-                .and_then(|value| value.to_str().ok())
-                // Empty string tells curl to fill in all supported encodings.
-                .unwrap_or(""),
-        )?;
 
         // Set the HTTP method to use. Curl ties in behavior with the request
         // method, so we need to configure this carefully.

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -26,6 +26,35 @@ fn gzip_encoded_response_is_decoded_automatically() {
 }
 
 #[test]
+fn request_gzip_without_automatic_decompression() {
+    let body = "hello world";
+    let mut body_encoded = Vec::new();
+
+    GzEncoder::new(body.as_bytes(), Compression::default())
+        .read_to_end(&mut body_encoded)
+        .unwrap();
+
+    let m = mock("GET", "/")
+        .match_header("Accept-Encoding", "gzip")
+        .with_header("Content-Encoding", "gzip")
+        .with_body(&body_encoded)
+        .create();
+
+    let mut response = Request::get(server_url())
+        .header("Accept-Encoding", "gzip")
+        .automatic_decompression(false)
+        .body(())
+        .unwrap()
+        .send()
+        .unwrap();
+    let mut body_received = Vec::new();
+    response.body_mut().read_to_end(&mut body_received).unwrap();
+
+    assert_eq!(body_received, body_encoded);
+    m.assert();
+}
+
+#[test]
 fn deflate_encoded_response_is_decoded_automatically() {
     let body = "hello world";
     let mut body_encoded = Vec::new();


### PR DESCRIPTION
Add a new option to disable (or enable) automatic response decompression. This also influences the default value of the `Accept-Encoding` header, but this can be overrided.

See #227.