### PR TITLE
Add a "Why not use" section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,14 @@ Non-goals:
 - Support for protocols other than HTTP.
 - Alternative engines besides libcurl. Other projects are better suited for this.
 
+## When would you *not* use Isahc?
+
+Not every library is perfect for every use-case. While Isahc strives to be a full-featured and general-purpose HTTP client that should work well for many projects, there are a few scenarios that Isahc is not well suited for:
+
+- **Tiny binaries**: If you are creating an application where tiny binary size is a key priority, you might find Isahc to be too large for you. While Isahc's dependencies are carefully curated and a number of features can be disabled, Isahc's core feature set includes things like async which does have some file size overhead. You might find something like [ureq] more suitable.
+- **WebAssembly support**: If your project needs to be able to be compiled to WebAssembly, then Isahc will probably not work for you. Instead you might like an HTTP client that supports multiple backends such as [Surf].
+- **Rustls support**: We hope to support [rustls] as a TLS backend someday, it is not currently supported directly. If for some reason rustls is a hard requirement for you, you'll need to use a different HTTP client for now.
+
 ## License
 
 This project's source code and documentation are licensed under the MIT license. See the [LICENSE](LICENSE) file for details.
@@ -118,4 +126,7 @@ The Isahc logo and related assets are licensed under a [Creative Commons Attribu
 [multi interface]: https://curl.haxx.se/libcurl/c/libcurl-multi.html
 [rfc4559]: https://tools.ietf.org/html/rfc4559
 [rust]: https://www.rustlang.org
+[rustls]: https://github.com/ctz/rustls
 [serde]: https://serde.rs
+[Surf]: https://github.com/http-rs/surf
+[ureq]: https://github.com/algesten/ureq


### PR DESCRIPTION
It's always nice when projects are open and honest about their shortcomings as well as their strengths. Add a section to the readme that highlights some key weaknesses of Isahc, along with some recommended alternatives.