### PR TITLE
Add Connection Cache TTL

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -790,6 +790,15 @@ impl SetOpt for MaxDownloadSpeed {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct MaxAgeConn(pub(crate) Duration);
+
+impl SetOpt for MaxAgeConn {
+    fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
+        easy.maxage_conn(self.0)
+    }
+}
+
 /// Close the connection when the request completes instead of returning it to
 /// the connection cache.
 #[derive(Clone, Debug)]


### PR DESCRIPTION
This patch uses the newly exposed curl configuration allowing for a client to set up a connection cache TTL.

Closes #93