### PR TITLE
Fix timeouts causing unexplained EOFs

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -167,7 +167,7 @@ impl From<Error> for io::Error {
             Error::ConnectFailed => io::ErrorKind::ConnectionRefused.into(),
             Error::Io(e) => e,
             Error::Timeout => io::ErrorKind::TimedOut.into(),
-            _ => io::ErrorKind::Other.into(),
+            e => io::Error::new(io::ErrorKind::Other, e),
         }
     }
 }

--- a/testserver/src/lib.rs
+++ b/testserver/src/lib.rs
@@ -24,7 +24,15 @@ macro_rules! mock {
     (@response($response:expr) body: $body:expr, $($tail:tt)*) => {{
         let mut response = $response;
 
-        response.body = $body.into();
+        response = response.with_body_buf($body);
+
+        $crate::mock!(@response(response) $($tail)*)
+    }};
+
+    (@response($response:expr) body_reader: $body:expr, $($tail:tt)*) => {{
+        let mut response = $response;
+
+        response = response.with_body_reader($body);
 
         $crate::mock!(@response(response) $($tail)*)
     }};
@@ -32,7 +40,9 @@ macro_rules! mock {
     (@response($response:expr) transfer_encoding: $value:expr, $($tail:tt)*) => {{
         let mut response = $response;
 
-        response.transfer_encoding = $value;
+        if $value {
+            response.body_len = None;
+        }
 
         $crate::mock!(@response(response) $($tail)*)
     }};

--- a/testserver/src/mock.rs
+++ b/testserver/src/mock.rs
@@ -112,8 +112,8 @@ impl<R: Responder> Mock<R> {
         Response {
             status_code: 404,
             headers: Vec::new(),
-            body: Vec::new(),
-            transfer_encoding: false,
+            body: Box::new(std::io::empty()),
+            body_len: Some(0),
         }
     }
 


### PR DESCRIPTION
If a request errors after the response headers have already been received, but the full response body has not been read yet, then the response body stream will begin returning EOF without any other explanation other than what is written to the logger. This gives the appearance that everything is fine but half of the response body is missing.

To fix this, be sure to communicate to the response stream when a transfer error occurs while streaming the response body, so that the next call to read from the response will return an appropriate error instead of an unexplained EOF.

This is especially an obvious problem when combined with the timeout option, which can very likely occur during reading of the response body, whereas most other errors are likely to occur before that time.

First raised in #154.