### PR TITLE
Improve documentation on timeouts

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -88,13 +88,6 @@ pub trait Configurable: internal::ConfigurableBase {
         self.configure(ConnectTimeout(timeout))
     }
 
-    /// Set a timeout for reading and writing from the server.
-    ///
-    /// If not set, no timeout will be enforced.
-    fn socket_timeout<T: Into<Option<Duration>>>(self, timeout: T) -> Self {
-        self.configure(SocketTimeout(timeout.into()))
-    }
-
     /// Configure how the use of HTTP versions should be negotiated with the
     /// server.
     ///
@@ -786,20 +779,6 @@ pub(crate) struct ConnectTimeout(pub(crate) Duration);
 impl SetOpt for ConnectTimeout {
     fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
         easy.connect_timeout(self.0)
-    }
-}
-
-#[derive(Clone, Debug)]
-pub(crate) struct SocketTimeout(pub(crate) Option<Duration>);
-
-impl SetOpt for SocketTimeout {
-    fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
-        if let Some(timeout) = self.0.clone() {
-            easy.low_speed_limit(1)?;
-            easy.low_speed_time(timeout)
-        } else {
-            easy.low_speed_limit(0)
-        }
     }
 }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -44,8 +44,22 @@ pub use ssl::{CaCertificate, ClientCertificate, PrivateKey, SslOption};
 ///
 /// This trait is sealed and cannot be implemented for types outside of Isahc.
 pub trait Configurable: internal::ConfigurableBase {
-    /// Set a maximum amount of time that a request is allowed to take before
-    /// being aborted.
+    /// Specify a maximum amount of time that a complete request/response cycle
+    /// is allowed to take before being aborted. This includes DNS resolution,
+    /// connecting to the server, writing the request, and reading the response.
+    ///
+    /// Since response bodies are streamed, you will likely receive a
+    /// [`Response`](crate::http::Response) before the response body stream has
+    /// been fully consumed. This means that the configured timeout will still
+    /// be active for that request, and if it expires, further attempts to read
+    /// from the stream will return a [`TimedOut`](std::io::ErrorKind::TimedOut)
+    /// I/O error.
+    ///
+    /// This also means that if you receive a response with a body but do not
+    /// immediately start reading from it, then the timeout timer will still be
+    /// active and may expire before you even attempt to read the body. Keep
+    /// this in mind when consuming responses and consider handling the response
+    /// body right after you receive it if you are using this option.
     ///
     /// If not set, no timeout will be enforced.
     ///
@@ -67,11 +81,18 @@ pub trait Configurable: internal::ConfigurableBase {
         self.configure(Timeout(timeout))
     }
 
-    /// Set a timeout for the initial connection phase.
+    /// Set a timeout for establishing connections to a host.
     ///
-    /// If not set, a connect timeout of 300 seconds will be used.
+    /// If not set, a default connect timeout of 300 seconds will be used.
     fn connect_timeout(self, timeout: Duration) -> Self {
         self.configure(ConnectTimeout(timeout))
+    }
+
+    /// Set a timeout for reading and writing from the server.
+    ///
+    /// If not set, no timeout will be enforced.
+    fn socket_timeout<T: Into<Option<Duration>>>(self, timeout: T) -> Self {
+        self.configure(SocketTimeout(timeout.into()))
     }
 
     /// Configure how the use of HTTP versions should be negotiated with the
@@ -765,6 +786,20 @@ pub(crate) struct ConnectTimeout(pub(crate) Duration);
 impl SetOpt for ConnectTimeout {
     fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
         easy.connect_timeout(self.0)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SocketTimeout(pub(crate) Option<Duration>);
+
+impl SetOpt for SocketTimeout {
+    fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
+        if let Some(timeout) = self.0.clone() {
+            easy.low_speed_limit(1)?;
+            easy.low_speed_time(timeout)
+        } else {
+            easy.low_speed_limit(0)
+        }
     }
 }
 

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -18,12 +18,7 @@ fn request_errors_if_read_timeout_is_reached() {
         .send();
 
     // Client should time-out.
-    match result {
-        Err(isahc::Error::Timeout) => {}
-        e => {
-            panic!("expected timeout error, got {:?}", e);
-        }
-    }
+    assert!(matches!(result, Err(isahc::Error::Timeout)));
 
     assert_eq!(m.requests().len(), 1);
 }


### PR DESCRIPTION
How timeouts are applied was a bit vague in our documentation and was causing some confusion. Add more detail to make it hopefully more clear as to what the timeout does, in particular that the timeout is still active even once the response headers are received and while the body has not been yet read.