### PR TITLE
Fix client-wide redirect policy not respected

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
       - name: Generate code coverage report
         uses: actions-rs/tarpaulin@v0.1
         with:
+          version: '0.16.0'
           args: "-p isahc --run-types Doctests Tests --features cookies,psl"
 
       - name: Upload coverage to Codecov


### PR DESCRIPTION
Fix a regression from #240 that caused redirect policies to be ignored if being set client-wide instead of per-request.

Fixes #250.