### PR TITLE
Add support for forcing a specific ip protocal version

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -986,7 +986,7 @@ impl HttpClient {
                 SslOption,
                 CloseConnection,
                 EnableMetrics,
-                IpProtocol,
+                IpVersion,
             ]
         );
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -986,6 +986,7 @@ impl HttpClient {
                 SslOption,
                 CloseConnection,
                 EnableMetrics,
+                IpProtocol,
             ]
         );
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -575,10 +575,14 @@ pub trait Configurable: internal::ConfigurableBase {
         self.configure(EnableMetrics(enable))
     }
 
-    /// Set a maximum upload speed for the request body, in bytes per second.
+    /// Select a specific IP version when resolving hostnames. If a given
+    /// hostname does not resolve to an IP address of the desired version, then
+    /// the request will fail with a connection error.
     ///
-    /// The default is unlimited.
-    fn ip_protocol(self, protocol: IpProtocol) -> Self {
+    /// This does not affect requests with an explicit IP address as the host.
+    ///
+    /// The default is IpProtocol::Any.
+    fn ip_version(self, protocol: IpVersion) -> Self {
         self.configure(protocol)
     }
 }
@@ -881,21 +885,21 @@ impl SetOpt for EnableMetrics {
 
 /// The ip protocol version to use
 #[derive(Clone, Debug)]
-pub enum IpProtocol {
-    /// Connect to ipv4 addresses only.
+pub enum IpVersion {
+    /// Resolve ipv4 addresses only.
     V4,
-    /// Connect to ipv6 addresses only.
+    /// Resolve ipv6 addresses only.
     V6,
-    /// Connect to any ip protocol version address.
+    /// Resolve both ipv4 and ipv6 addresses.
     Any,
 }
 
-impl SetOpt for IpProtocol {
+impl SetOpt for IpVersion {
     fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
         let proto = match &self {
-            IpProtocol::V4 => curl::easy::IpResolve::V4,
-            IpProtocol::V6 => curl::easy::IpResolve::V6,
-            IpProtocol::Any => curl::easy::IpResolve::Any,
+            IpVersion::V4 => curl::easy::IpResolve::V4,
+            IpVersion::V6 => curl::easy::IpResolve::V6,
+            IpVersion::Any => curl::easy::IpResolve::Any,
         };
         easy.ip_resolve(proto)
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -574,6 +574,13 @@ pub trait Configurable: internal::ConfigurableBase {
     fn metrics(self, enable: bool) -> Self {
         self.configure(EnableMetrics(enable))
     }
+
+    /// Set a maximum upload speed for the request body, in bytes per second.
+    ///
+    /// The default is unlimited.
+    fn ip_protocol(self, protocol: IpProtocol) -> Self {
+        self.configure(protocol)
+    }
 }
 
 /// A strategy for selecting what HTTP versions should be used when
@@ -869,6 +876,28 @@ pub(crate) struct EnableMetrics(pub(crate) bool);
 impl SetOpt for EnableMetrics {
     fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
         easy.progress(self.0)
+    }
+}
+
+/// The ip protocol version to use
+#[derive(Clone, Debug)]
+pub enum IpProtocol {
+    /// Connect to ipv4 addresses only.
+    V4,
+    /// Connect to ipv6 addresses only.
+    V6,
+    /// Connect to any ip protocol version address.
+    Any,
+}
+
+impl SetOpt for IpProtocol {
+    fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
+        let proto = match &self {
+            IpProtocol::V4 => curl::easy::IpResolve::V4,
+            IpProtocol::V6 => curl::easy::IpResolve::V6,
+            IpProtocol::Any => curl::easy::IpResolve::Any,
+        };
+        easy.ip_resolve(proto)
     }
 }
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -98,6 +98,7 @@ impl<T> RequestExt<T> for Request<T> {
                 crate::config::SslOption,
                 crate::config::CloseConnection,
                 crate::config::EnableMetrics,
+                crate::config::IpProtocol,
             ]
         );
 

--- a/src/request.rs
+++ b/src/request.rs
@@ -98,7 +98,7 @@ impl<T> RequestExt<T> for Request<T> {
                 crate::config::SslOption,
                 crate::config::CloseConnection,
                 crate::config::EnableMetrics,
-                crate::config::IpProtocol,
+                crate::config::IpVersion,
             ]
         );
 


### PR DESCRIPTION
Support specifying the ip protocol version to use, like to `curl -4` and `curl -6`.
fixes #252