### PR TITLE
Trim some heavy dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,17 +32,16 @@ unstable-interceptors = []
 
 [dependencies]
 bytes = "0.5"
-crossbeam-channel = "0.5"
 crossbeam-utils = "0.8"
 curl = "0.4.34"
 curl-sys = "0.4.37"
-futures-channel = "0.3"
-futures-io = "0.3"
+futures-lite = "1.11"
 http = "0.2.1"
 log = "0.4"
 once_cell = "1"
 slab = "0.4"
 sluice = "0.5"
+waker-fn = "1"
 
 [dependencies.chrono]
 version = "0.4"
@@ -52,10 +51,10 @@ optional = true
 version = "0.8"
 optional = true
 
-[dependencies.futures-util]
-version = "0.3"
+[dependencies.flume]
+version = "0.9"
 default-features = false
-features = ["io"]
+features = ["async"]
 
 [dependencies.mime]
 version = "0.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -1132,7 +1132,6 @@ impl Future for ResponseFuture<'_> {
     type Output = Result<Response<Body>, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        // use futures_util::future::FutureExt;
         self.0.as_mut().poll(cx)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -9,11 +9,9 @@ use crate::{
     handler::{RequestHandler, ResponseBodyReader},
     headers,
     interceptor::{self, Interceptor, InterceptorObj},
-    task::Join,
     Body, Error,
 };
-use futures_io::AsyncRead;
-use futures_util::{future::BoxFuture, pin_mut};
+use futures_lite::{future::block_on, io::AsyncRead, pin};
 use http::{
     header::{HeaderMap, HeaderName, HeaderValue},
     Request, Response,
@@ -650,7 +648,7 @@ impl HttpClient {
         http::Uri: TryFrom<U>,
         <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
-        self.get_async(uri).join()
+        block_on(self.get_async(uri))
     }
 
     /// Send a GET request to the given URI asynchronously.
@@ -685,7 +683,7 @@ impl HttpClient {
         http::Uri: TryFrom<U>,
         <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
-        self.head_async(uri).join()
+        block_on(self.head_async(uri))
     }
 
     /// Send a HEAD request to the given URI asynchronously.
@@ -723,7 +721,7 @@ impl HttpClient {
         http::Uri: TryFrom<U>,
         <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
-        self.post_async(uri, body).join()
+        block_on(self.post_async(uri, body))
     }
 
     /// Send a POST request to the given URI asynchronously with a given request
@@ -763,7 +761,7 @@ impl HttpClient {
         http::Uri: TryFrom<U>,
         <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
-        self.put_async(uri, body).join()
+        block_on(self.put_async(uri, body))
     }
 
     /// Send a PUT request to the given URI asynchronously with a given request
@@ -789,7 +787,7 @@ impl HttpClient {
         http::Uri: TryFrom<U>,
         <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
     {
-        self.delete_async(uri).join()
+        block_on(self.delete_async(uri))
     }
 
     /// Send a DELETE request to the given URI asynchronously.
@@ -855,7 +853,7 @@ impl HttpClient {
     #[inline]
     #[tracing::instrument(level = "debug", skip(self, request), err)]
     pub fn send<B: Into<Body>>(&self, request: Request<B>) -> Result<Response<Body>, Error> {
-        self.send_async(request).join()
+        block_on(self.send_async(request))
     }
 
     /// Send an HTTP request and return the HTTP response asynchronously.
@@ -1122,7 +1120,7 @@ impl fmt::Debug for HttpClient {
 }
 
 /// A future for a request being executed.
-pub struct ResponseFuture<'c>(BoxFuture<'c, Result<Response<Body>, Error>>);
+pub struct ResponseFuture<'c>(Pin<Box<dyn Future<Output = Result<Response<Body>, Error>> + 'c + Send>>);
 
 impl<'c> ResponseFuture<'c> {
     fn new(future: impl Future<Output = Result<Response<Body>, Error>> + Send + 'c) -> Self {
@@ -1134,8 +1132,8 @@ impl Future for ResponseFuture<'_> {
     type Output = Result<Response<Body>, Error>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
-        use futures_util::future::FutureExt;
-        self.0.poll_unpin(cx)
+        // use futures_util::future::FutureExt;
+        self.0.as_mut().poll(cx)
     }
 }
 
@@ -1159,7 +1157,7 @@ impl AsyncRead for ResponseBody {
         buf: &mut [u8],
     ) -> Poll<io::Result<usize>> {
         let inner = &mut self.inner;
-        pin_mut!(inner);
+        pin!(inner);
         inner.poll_read(cx, buf)
     }
 }

--- a/src/interceptor/mod.rs
+++ b/src/interceptor/mod.rs
@@ -28,11 +28,12 @@
 /// enabled.
 
 use crate::Body;
-use futures_util::future::BoxFuture;
 use http::{Request, Response};
 use std::{
     error::Error,
     fmt,
+    future::Future,
+    pin::Pin,
 };
 
 mod context;
@@ -81,7 +82,7 @@ pub trait Interceptor: Send + Sync {
 }
 
 /// The type of future returned by an interceptor.
-pub type InterceptorFuture<'a, E> = BoxFuture<'a, Result<Response<Body>, E>>;
+pub type InterceptorFuture<'a, E> = Pin<Box<dyn Future<Output = Result<Response<Body>, E>> + Send + 'a>>;
 
 /// Creates an interceptor from an arbitrary closure or function.
 pub fn from_fn<F, E>(f: F) -> InterceptorFn<F>

--- a/src/response.rs
+++ b/src/response.rs
@@ -144,7 +144,7 @@ pub trait ResponseExt<T> {
     #[cfg(feature = "text-decoding")]
     fn text_async(&mut self) -> crate::text::TextFuture<'_, &mut T>
     where
-        T: futures_io::AsyncRead + Unpin;
+        T: futures_lite::io::AsyncRead + Unpin;
 
     /// Deserialize the response body as JSON into a given type.
     ///
@@ -210,7 +210,7 @@ impl<T> ResponseExt<T> for Response<T> {
     #[cfg(feature = "text-decoding")]
     fn text_async(&mut self) -> crate::text::TextFuture<'_, &mut T>
     where
-        T: futures_io::AsyncRead + Unpin,
+        T: futures_lite::io::AsyncRead + Unpin,
     {
         crate::text::Decoder::for_response(&self).decode_reader_async(self.body_mut())
     }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,5 @@
 use crate::Metrics;
+use futures_lite::io::AsyncRead;
 use http::{Response, Uri};
 use std::{
     fs::File,
@@ -144,7 +145,7 @@ pub trait ResponseExt<T> {
     #[cfg(feature = "text-decoding")]
     fn text_async(&mut self) -> crate::text::TextFuture<'_, &mut T>
     where
-        T: futures_lite::io::AsyncRead + Unpin;
+        T: AsyncRead + Unpin;
 
     /// Deserialize the response body as JSON into a given type.
     ///
@@ -210,7 +211,7 @@ impl<T> ResponseExt<T> for Response<T> {
     #[cfg(feature = "text-decoding")]
     fn text_async(&mut self) -> crate::text::TextFuture<'_, &mut T>
     where
-        T: futures_lite::io::AsyncRead + Unpin,
+        T: AsyncRead + Unpin,
     {
         crate::text::Decoder::for_response(&self).decode_reader_async(self.body_mut())
     }

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,58 +1,10 @@
 //! Helpers for working with tasks and futures.
 
 use crate::Error;
-use crossbeam_utils::sync::{Parker, Unparker};
-use futures_util::{pin_mut, task::ArcWake};
 use std::{
-    future::Future,
     net::{SocketAddr, UdpSocket},
-    sync::Arc,
-    task::{Context, Poll, Waker},
+    task::Waker,
 };
-
-/// Extension trait for efficiently blocking on a future.
-pub(crate) trait Join: Future {
-    fn join(self) -> <Self as Future>::Output;
-}
-
-impl<F: Future> Join for F {
-    fn join(self) -> <Self as Future>::Output {
-        struct ThreadWaker(Unparker);
-
-        impl ArcWake for ThreadWaker {
-            fn wake_by_ref(arc_self: &Arc<Self>) {
-                arc_self.0.unpark();
-            }
-        }
-
-        let parker = Parker::new();
-        let waker = futures_util::task::waker(Arc::new(ThreadWaker(parker.unparker().clone())));
-        let mut context = Context::from_waker(&waker);
-
-        let future = self;
-        pin_mut!(future);
-
-        loop {
-            match future.as_mut().poll(&mut context) {
-                Poll::Ready(output) => return output,
-                Poll::Pending => parker.park(),
-            }
-        }
-    }
-}
-
-/// Create a waker from a closure.
-fn waker_fn(f: impl Fn() + Send + Sync + 'static) -> Waker {
-    struct Impl<F>(F);
-
-    impl<F: Fn() + Send + Sync + 'static> ArcWake for Impl<F> {
-        fn wake_by_ref(arc_self: &Arc<Self>) {
-            (&arc_self.0)()
-        }
-    }
-
-    futures_util::task::waker(Arc::new(Impl(f)))
-}
 
 /// Helper methods for working with wakers.
 pub(crate) trait WakerExt {
@@ -64,7 +16,7 @@ pub(crate) trait WakerExt {
 impl WakerExt for Waker {
     fn chain(&self, f: impl Fn(&Waker) + Send + Sync + 'static) -> Waker {
         let inner = self.clone();
-        waker_fn(move || (f)(&inner))
+        waker_fn::waker_fn(move || (f)(&inner))
     }
 }
 
@@ -87,14 +39,14 @@ impl UdpWaker {
     }
 }
 
-impl ArcWake for UdpWaker {
-    /// Request the connected agent event loop to wake up. Just like a morning
-    /// person would do.
-    fn wake_by_ref(arc_self: &Arc<Self>) {
-        // We don't actually care here if this succeeds. Maybe the agent is
-        // busy, or tired, or just needs some alone time right now.
-        if let Err(e) = arc_self.socket.send(&[1]) {
-            tracing::debug!("agent waker produced an error: {}", e);
-        }
+impl From<UdpWaker> for Waker {
+    fn from(waker: UdpWaker) -> Self {
+        waker_fn::waker_fn(move || {
+            // We don't actually care here if this succeeds. Maybe the agent is
+            // busy, or tired, or just needs some alone time right now.
+            if let Err(e) = waker.socket.send(&[1]) {
+                tracing::debug!("agent waker produced an error: {}", e);
+            }
+        })
     }
 }


### PR DESCRIPTION
Tis the season to be trimming the tree! Reducing dependencies where it makes sense is a regular task for Isahc to ensure shorter compile times, binary size, or package size.

This time around the goal was to eliminate `futures-util` from the essential dependencies, since it has long compile times. This included swapping out for `futures-lite` where needed, or just using our own code, as well as updating Sluice to remove `futures-util` from there as well.

Also a goal was to unify our preferred channel implementation, since we currently use _both_ `futures-channel` and `crossbeam-channel`, depending on the scenario. Here we can replace both with `flume` which has the nice property of supporting both sync and async operations on one channel.