### PR TITLE
Fix redirect handling with response bodies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ log = "0.4"
 once_cell = "1"
 slab = "0.4"
 sluice = "0.5"
+url = "2.2"
 waker-fn = "1"
 
 [dependencies.chrono]

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -3,19 +3,20 @@ use crate::{
     handler::RequestBody,
     interceptor::{Context, Interceptor, InterceptorFuture},
     request::RequestExt,
-    Body,
-    Error,
+    Body, Error,
 };
-use http::{Request, Uri};
+use http::{Request, Response, Uri};
+use std::convert::TryFrom;
+use url::Url;
 
 /// How many redirects to follow by default if a limit is not specified. We
 /// don't actually allow infinite redirects as that could result in a dangerous
 /// infinite loop, so by default we actually limit redirects to a large amount.
 const DEFAULT_REDIRECT_LIMIT: u32 = 1024;
 
-/// Extension containing the redirect target on the response determined by curl,
-/// if any.
-pub(crate) struct RedirectUri(pub(crate) Uri);
+/// Extension containing the final "effective" URI that was visited, after
+/// following any redirects.
+pub(crate) struct EffectiveUri(pub(crate) Uri);
 
 /// Interceptor that implements automatic following of HTTP redirects.
 pub(crate) struct RedirectInterceptor;
@@ -23,95 +24,149 @@ pub(crate) struct RedirectInterceptor;
 impl Interceptor for RedirectInterceptor {
     type Err = Error;
 
-    fn intercept<'a>(&'a self, request: Request<Body>, ctx: Context<'a>) -> InterceptorFuture<'a, Self::Err> {
+    fn intercept<'a>(
+        &'a self,
+        mut request: Request<Body>,
+        ctx: Context<'a>,
+    ) -> InterceptorFuture<'a, Self::Err> {
         Box::pin(async move {
+            // Store the effective URI to include in the response.
+            let mut effective_uri = request.uri().clone();
+
             // Get the redirect policy for this request.
-            let policy = request.extensions()
+            let policy = request
+                .extensions()
                 .get::<RedirectPolicy>()
                 .cloned()
                 .unwrap_or_default();
 
             // No redirect handling, just proceed normally.
             if policy == RedirectPolicy::None {
-                return ctx.send(request).await;
+                let mut response = ctx.send(request).await?;
+                response
+                    .extensions_mut()
+                    .insert(EffectiveUri(effective_uri));
+
+                return Ok(response);
             }
 
-            let auto_referer = request.extensions()
+            let auto_referer = request
+                .extensions()
                 .get::<crate::config::redirect::AutoReferer>()
                 .is_some();
 
-            // Make a copy of the request before sending it.
-            let mut request_builder = request.to_builder();
-
-            // Send the request to get the ball rolling.
-            let mut response = ctx.send(request).await?;
-
-            let mut redirect_count: u32 = 0;
             let limit = match policy {
                 RedirectPolicy::Limit(limit) => limit,
                 _ => DEFAULT_REDIRECT_LIMIT,
             };
 
-            // Check for redirects. If a redirect should happen, then curl will
-            // return a URI to redirect to, which the request handler will
-            // attach to the response as this extension.
-            while let Some(RedirectUri(redirect_uri)) = response.extensions_mut().remove::<RedirectUri>() {
-                // Sanity check.
-                if !response.status().is_redirection() {
-                    break;
+            // Keep track of how many redirects we've done.
+            let mut redirect_count: u32 = 0;
+
+            loop {
+                // Preserve a clone of the request before sending it.
+                let mut request_builder = request.to_builder();
+
+                // Send the request to get the ball rolling.
+                let mut response = ctx.send(request).await?;
+
+                // Check for a redirect.
+                if let Some(location) = get_redirect_location(&effective_uri, &response) {
+                    // If we've reached the limit, return an error as requested.
+                    if redirect_count >= limit {
+                        return Err(Error::TooManyRedirects);
+                    }
+
+                    // Set referer header.
+                    if auto_referer {
+                        let referer = request_builder.uri_ref().unwrap().to_string();
+                        request_builder = request_builder.header(http::header::REFERER, referer);
+                    }
+
+                    // Check if we should change the request method into a GET. HTTP
+                    // specs don't really say one way or another when this should
+                    // happen for most status codes, so we just mimic curl's
+                    // behavior here since it is so common.
+                    if response.status() == 301 || response.status() == 302 || response.status() == 303
+                    {
+                        request_builder = request_builder.method(http::Method::GET);
+                    }
+
+                    // Grab the request body back from the internal handler, as we
+                    // might need to send it again (if possible...)
+                    let mut request_body = response
+                        .extensions_mut()
+                        .remove::<RequestBody>()
+                        .map(|v| v.0)
+                        .unwrap_or_default();
+
+                    // Redirect handling is tricky when we are uploading something.
+                    // If we can, reset the body stream to the beginning. This might
+                    // work if the body to upload is an in-memory byte buffer, but
+                    // for arbitrary streams we can't do this.
+                    //
+                    // There's not really a good way of handling this gracefully, so
+                    // we just return an error so that the user knows about it.
+                    if !request_body.reset() {
+                        return Err(Error::RequestBodyError(Some(String::from(
+                            "could not follow redirect because request body is not rewindable",
+                        ))));
+                    }
+
+                    // Update the request to point to the new URI.
+                    effective_uri = location.clone();
+                    request = request_builder.uri(location).body(request_body)?;
+                    redirect_count += 1;
                 }
 
-                // If we've reached the limit, return an error as requested.
-                if redirect_count >= limit {
-                    return Err(Error::TooManyRedirects);
+                // No more redirects; set the effective URI we finally settled on and return.
+                else {
+                    response
+                        .extensions_mut()
+                        .insert(EffectiveUri(effective_uri));
+
+                    return Ok(response);
                 }
-
-                // Set referer header.
-                if auto_referer {
-                    let referer = request_builder.uri_ref().unwrap().to_string();
-                    request_builder = request_builder.header(http::header::REFERER, referer);
-                }
-
-                // Check if we should change the request method into a GET. HTTP
-                // specs don't really say one way or another when this should
-                // happen for most status codes, so we just mimic curl's
-                // behavior here since it is so common.
-                if response.status() == 301 || response.status() == 302 || response.status() == 303 {
-                    request_builder = request_builder.method(http::Method::GET);
-                }
-
-                // Grab the request body back from the internal handler, as we
-                // might need to send it again (if possible...)
-                let mut request_body = response.extensions_mut()
-                    .remove::<RequestBody>()
-                    .map(|v| v.0)
-                    .unwrap_or_default();
-
-                // Redirect handling is tricky when we are uploading something.
-                // If we can, reset the body stream to the beginning. This might
-                // work if the body to upload is an in-memory byte buffer, but
-                // for arbitrary streams we can't do this.
-                //
-                // There's not really a good way of handling this gracefully, so
-                // we just return an error so that the user knows about it.
-                if !request_body.reset() {
-                    return Err(Error::RequestBodyError(Some(String::from("could not follow redirect because request body is not rewindable"))));
-                }
-
-                let request = request_builder.uri(redirect_uri)
-                    .body(request_body)?;
-
-                // Keep another clone of the request around again, in case we
-                // need to follow yet another redirect.
-                request_builder = request.to_builder();
-
-                // Send the redirected request.
-                response = ctx.send(request).await?;
-
-                redirect_count += 1;
             }
-
-            Ok(response)
         })
+    }
+}
+
+fn get_redirect_location<T>(request_uri: &Uri, response: &Response<T>) -> Option<Uri> {
+    if response.status().is_redirection() {
+        let location = response.headers().get(http::header::LOCATION)?;
+
+        match location.to_str() {
+            Ok(location) => {
+                match resolve(request_uri, location) {
+                    Ok(uri) => return Some(uri),
+                    Err(e) => {
+                        tracing::debug!("bad redirect location: {}", e);
+                    }
+                }
+            }
+            Err(e) => {
+                tracing::debug!("bad redirect location: {}", e);
+            }
+        }
+    }
+
+    None
+}
+
+/// Resolve one URI in terms of another.
+fn resolve(base: &Uri, target: &str) -> Result<Uri, Box<dyn std::error::Error>> {
+    // Optimistically check if this is an absolute URI.
+    match Url::parse(target) {
+        Ok(url) => Ok(Uri::try_from(url.as_str())?),
+
+        // Relative URI, resolve against the base.
+        Err(url::ParseError::RelativeUrlWithoutBase) => {
+            let base = Url::parse(base.to_string().as_str())?;
+
+            Ok(Uri::try_from(base.join(target)?.as_str())?)
+        }
+
+        Err(e) => Err(Box::new(e)),
     }
 }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,4 @@
-use crate::Metrics;
+use crate::{redirect::EffectiveUri, Metrics};
 use futures_lite::io::AsyncRead;
 use http::{Response, Uri};
 use std::{
@@ -225,8 +225,6 @@ impl<T> ResponseExt<T> for Response<T> {
         serde_json::from_reader(self.body_mut())
     }
 }
-
-pub(crate) struct EffectiveUri(pub(crate) Uri);
 
 pub(crate) struct LocalAddr(pub(crate) SocketAddr);
 

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -146,6 +146,36 @@ fn redirect_also_sends_post(status: u16) {
 
 // Issue #250
 #[test]
+fn redirect_with_response_body() {
+    let m2 = mock! {
+        body: "OK",
+    };
+    let location = m2.url();
+
+    let m1 = mock! {
+        status: 302,
+        headers {
+            "Location": location,
+        }
+        body: "REDIRECT",
+    };
+
+    let response = Request::post(m1.url())
+        .redirect_policy(RedirectPolicy::Follow)
+        .body(())
+        .unwrap()
+        .send()
+        .unwrap();
+
+    assert_eq!(response.status(), 200);
+    assert_eq!(response.effective_uri().unwrap().to_string(), m2.url());
+
+    assert_eq!(m1.request().method, "POST");
+    assert_eq!(m2.request().method, "GET");
+}
+
+// Issue #250
+#[test]
 fn redirect_policy_from_client() {
     let m2 = mock!();
     let location = m2.url();


### PR DESCRIPTION
Previously we were relying on curl to resolve the redirect location with `CURLINFO_REDIRECT_URL`, but this value is only populated once the response body stream has been consumed and the handle is complete. This means that redirects were working properly if the response containing the redirect had an empty body, but not if a nonempty body is included.

Since we don't really want to wait for the response body to be consumed before we decide whether we should redirect or not, change the redirect interceptor to derive the redirect location ourselves. Since the algorithm is nontrivial, pull in the `url` crate to do this resolution.

Also add a test for following redirects when response bodies are present to catch this bug.

Fixes #250.