### PR TITLE
Error type updates

### DIFF
--- a/src/agent.rs
+++ b/src/agent.rs
@@ -8,14 +8,17 @@
 //! Since request executions are driven through futures, the agent also acts as
 //! a specialized task executor for tasks related to requests.
 
-use crate::handler::RequestHandler;
-use crate::task::{UdpWaker, WakerExt};
-use crate::Error;
+use crate::{
+    error::Error,
+    handler::RequestHandler,
+    task::{UdpWaker, WakerExt},
+};
 use crossbeam_utils::sync::WaitGroup;
 use curl::multi::WaitFd;
 use flume::{Receiver, Sender};
 use slab::Slab;
 use std::{
+    io,
     net::UdpSocket,
     sync::Mutex,
     task::Waker,
@@ -54,7 +57,7 @@ impl AgentBuilder {
 
     /// Spawn a new agent using the configuration in this builder and return a
     /// handle for communicating with the agent.
-    pub(crate) fn spawn(&self) -> Result<Handle, Error> {
+    pub(crate) fn spawn(&self) -> io::Result<Handle> {
         let create_start = Instant::now();
 
         // Initialize libcurl, if necessary, on the current thread.

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -15,11 +15,13 @@ use crossbeam_channel::{Receiver, Sender};
 use crossbeam_utils::sync::WaitGroup;
 use curl::multi::WaitFd;
 use slab::Slab;
-use std::net::UdpSocket;
-use std::sync::{Arc, Mutex};
-use std::task::Waker;
-use std::thread;
-use std::time::{Duration, Instant};
+use std::{
+    net::UdpSocket,
+    sync::{Arc, Mutex},
+    task::Waker,
+    thread,
+    time::{Duration, Instant},
+};
 
 const WAIT_TIMEOUT: Duration = Duration::from_millis(100);
 

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -17,7 +17,7 @@ use flume::{Receiver, Sender};
 use slab::Slab;
 use std::{
     net::UdpSocket,
-    sync::{Arc, Mutex},
+    sync::Mutex,
     task::Waker,
     thread,
     time::{Duration, Instant},

--- a/src/body.rs
+++ b/src/body.rs
@@ -10,28 +10,6 @@ use std::{
     task::{Context, Poll},
 };
 
-macro_rules! match_type {
-    {
-        $(
-            <$name:ident as $T:ty> => $branch:expr,
-        )*
-        $defaultName:ident => $defaultBranch:expr,
-    } => {{
-        match () {
-            $(
-                _ if ::std::any::Any::type_id(&$name) == ::std::any::TypeId::of::<$T>() => {
-                    #[allow(unsafe_code)]
-                    let $name: $T = unsafe {
-                        ::std::mem::transmute_copy::<_, $T>(&::std::mem::ManuallyDrop::new($name))
-                    };
-                    $branch
-                }
-            )*
-            _ => $defaultBranch,
-        }
-    }};
-}
-
 /// Contains the body of an HTTP request or response.
 ///
 /// This type is used to encapsulate the underlying stream or region of memory

--- a/src/client.rs
+++ b/src/client.rs
@@ -3,13 +3,14 @@
 use crate::{
     agent::{self, AgentBuilder},
     auth::{Authentication, Credentials},
+    body::Body,
     config::internal::{ConfigurableBase, SetOpt},
     config::*,
     default_headers::DefaultHeadersInterceptor,
+    error::{Error, ErrorKind},
     handler::{RequestHandler, ResponseBodyReader},
     headers,
     interceptor::{self, Interceptor, InterceptorObj},
-    Body, Error,
 };
 use futures_lite::{future::block_on, io::AsyncRead, pin};
 use http::{
@@ -450,14 +451,14 @@ impl HttpClientBuilder {
 
         #[cfg(not(feature = "cookies"))]
         let inner = Inner {
-            agent: self.agent_builder.spawn()?,
+            agent: self.agent_builder.spawn().map_err(|e| Error::new(ErrorKind::ClientInitialization, e))?,
             defaults: self.defaults,
             interceptors: self.interceptors,
         };
 
         #[cfg(feature = "cookies")]
         let inner = Inner {
-            agent: self.agent_builder.spawn()?,
+            agent: self.agent_builder.spawn().map_err(|e| Error::new(ErrorKind::ClientInitialization, e))?,
             defaults: self.defaults,
             interceptors: self.interceptors,
             cookie_jar: self.cookie_jar,

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -44,8 +44,17 @@ pub use ssl::{CaCertificate, ClientCertificate, PrivateKey, SslOption};
 ///
 /// This trait is sealed and cannot be implemented for types outside of Isahc.
 pub trait Configurable: internal::ConfigurableBase {
-    /// Set a maximum amount of time that a request is allowed to take before
-    /// being aborted.
+    /// Specify a maximum amount of time that a single request/response cycle is
+    /// allowed to take before being aborted.
+    ///
+    /// Since response bodies are streamed (if present) as part of the response
+    /// lifecycle, the timeout includes reading the response body stream. If the
+    /// response headers are received, but the timeout expires while reading the
+    /// response body, then read operations will return a
+    /// [`TimedOut`][std::io::ErrorKind::TimedOut] I/O error. This also means
+    /// that if you receive a response with a body but do not immediately start
+    /// reading from it, then the timeout timer will still be active and may
+    /// expire before you even attempt to read the body.
     ///
     /// If not set, no timeout will be enforced.
     ///

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -170,7 +170,8 @@ pub trait Configurable: internal::ConfigurableBase {
     /// decode the HTTP response body for known and available compression
     /// algorithms. If the server returns a response with an unknown or
     /// unavailable encoding, Isahc will return an
-    /// [`InvalidContentEncoding`](crate::Error::InvalidContentEncoding) error.
+    /// [`InvalidContentEncoding`](crate::error::ErrorKind::InvalidContentEncoding)
+    /// error.
     ///
     /// If you do not specify a specific value for the
     /// [`Accept-Encoding`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept-Encoding)

--- a/src/error.rs
+++ b/src/error.rs
@@ -125,6 +125,10 @@ impl PartialEq<ErrorKind> for &'_ ErrorKind {
 /// It is recommended that you use the [`kind`][Error::kind] method to get a
 /// more generalized classification of error types that this error could be if
 /// you need to handle different sorts of errors in different ways.
+///
+/// If you need to get more specific details about the reason for the error, you
+/// can use the [`source`][std::error::Error::source] method. We do not provide
+/// any stability guarantees about what error sources are returned.
 #[derive(Clone)]
 pub struct Error(Arc<Inner>);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -248,7 +248,7 @@ impl From<Error> for io::Error {
     fn from(mut error: Error) -> Self {
         // If this error was directly created from an IO error, return it
         // directly.
-        if matches!(error.kind, ErrorKind::Io(_)) {
+        if let ErrorKind::Io(_) = error.kind {
             if let Some(source) = error.source.take() {
                 match source.downcast() {
                     Ok(e) => return *e,

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,210 +1,346 @@
 //! Types for error handling.
 
-use std::error::Error as StdError;
-use std::fmt;
-use std::io;
+use std::{any::TypeId, error::Error as StdError, fmt, io};
 
-/// All possible types of errors that can be returned from Isahc.
-#[derive(Debug)]
-pub enum Error {
-    /// The request was aborted before it could be completed.
-    Aborted,
+/// A list of error types that can occur while sending an HTTP request or
+/// receiving an HTTP response.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[non_exhaustive]
+pub enum ErrorKind {
     /// A problem occurred with the local certificate.
-    BadClientCertificate(Option<String>),
+    BadClientCertificate,
+
     /// The server certificate could not be validated.
-    BadServerCertificate(Option<String>),
+    BadServerCertificate,
+
     /// Failed to connect to the server.
-    ConnectFailed,
+    ConnectionFailed,
+
     /// Couldn't resolve host name.
     CouldntResolveHost,
+
     /// Couldn't resolve proxy host name.
     CouldntResolveProxy,
 
-    /// Unrecognized or bad content encoding returned by the server.
-    InvalidContentEncoding(Option<String>),
-    /// Provided credentials were rejected by the server.
+    /// The server either returned a response using an unknown or unsupported
+    /// encoding format, or the response encoding was malformed.
+    InvalidContentEncoding,
+
+    /// Provided authentication credentials were rejected by the server.
     InvalidCredentials,
-    /// Validation error when constructing the request or parsing the response.
-    InvalidHttpFormat(http::Error),
-    /// Invalid UTF-8 string error.
-    InvalidUtf8,
-    /// An unknown I/O error.
-    Io(io::Error),
-    /// The server did not send a response.
-    NoResponse,
-    /// The server does not support or accept range requests.
-    RangeRequestUnsupported,
-    /// An error occurred while writing the request body.
-    RequestBodyError(Option<String>),
-    /// An error occurred while reading the response body.
-    ResponseBodyError(Option<String>),
-    /// Failed to connect over a secure socket.
-    SSLConnectFailed(Option<String>),
-    /// An error ocurred in the secure socket engine.
-    SSLEngineError(Option<String>),
-    /// An ongoing request took longer than the configured timeout time.
+
+    /// An I/O error either sending the request or reading the response. This
+    /// could be caused by a problem on the client machine, a problem on the
+    /// server machine, or a problem with the network between the two.
+    Io(std::io::ErrorKind),
+
+    /// The server made an unrecoverable HTTP protocol violation. This indicates
+    /// a bug in the server. Retrying a request that returns this error is
+    /// likely to produce the same error.
+    Protocol,
+
+    /// Request processing could not continue because the client needed to
+    /// re-send the request body, but was unable to rewind the body stream to
+    /// the beginning in order to do so.
+    RequestBodyNotRewindable,
+
+    /// A request or operation took longer than the configured timeout time.
     Timeout,
+
+    /// An error ocurred in the secure socket engine.
+    TlsEngineError,
+
     /// Number of redirects hit the maximum amount.
     TooManyRedirects,
 
-    Other(Box<dyn StdError>),
+    /// An unknown error occurred. This likely indicates a problem in the HTTP
+    /// client or in a dependency, but the client was able to recover instead of
+    /// panicking. Subsequent requests will likely succeed.
+    Unknown,
 }
 
-#[derive(Clone, Debug)]
-#[non_exhaustive]
-pub enum Category {
-    /// An I/O error either sending the request or reading the response. Unclear
-    /// if the client or server is to blame.
-    Io,
-
-    /// The server made an unrecoverable HTTP protocol violation. Retrying a
-    /// request is likely to produce the same error.
-    Protocol,
-
-    Timeout,
+impl fmt::Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::RequestBodyNotRewindable => {
+                f.write_str("request body could not be re-sent because it is not rewindable")
+            }
+            _ => f.write_str("unknown error"),
+        }
+    }
 }
+
+/// An error encountered while sending an HTTP request or receiving an HTTP
+/// response.
+#[derive(Debug)]
+pub struct Error {
+    kind: ErrorKind,
+    source: Option<Box<dyn StdError + Send + Sync + 'static>>,
+}
+
+// /// All possible types of errors that can be returned from Isahc.
+// #[derive(Debug)]
+// #[non_exhaustive]
+// pub enum Error {
+//     /// The request was aborted before it could be completed.
+//     Aborted,
+//     /// A problem occurred with the local certificate.
+//     BadClientCertificate(Option<String>),
+//     /// The server certificate could not be validated.
+//     BadServerCertificate(Option<String>),
+//     /// Failed to connect to the server.
+//     ConnectFailed,
+//     /// Couldn't resolve host name.
+//     CouldntResolveHost,
+//     /// Couldn't resolve proxy host name.
+//     CouldntResolveProxy,
+//     /// Unrecognized or bad content encoding returned by the server.
+//     InvalidContentEncoding(Option<String>),
+//     /// Provided credentials were rejected by the server.
+//     InvalidCredentials,
+//     /// Validation error when constructing the request or parsing the response.
+//     InvalidHttpFormat(http::Error),
+//     /// Invalid UTF-8 string error.
+//     InvalidUtf8,
+//     /// An unknown I/O error.
+//     Io(io::Error),
+//     /// The server did not send a response.
+//     NoResponse,
+//     /// The server does not support or accept range requests.
+//     RangeRequestUnsupported,
+//     /// An error occurred while writing the request body.
+//     RequestBodyError(Option<String>),
+//     /// An error occurred while reading the response body.
+//     ResponseBodyError(Option<String>),
+//     /// Failed to connect over a secure socket.
+//     SSLConnectFailed(Option<String>),
+//     /// An error ocurred in the secure socket engine.
+//     SSLEngineError(Option<String>),
+//     /// An ongoing request took longer than the configured timeout time.
+//     Timeout,
+//     /// Number of redirects hit the maximum amount.
+//     TooManyRedirects,
+
+//     Other(Box<dyn StdError + Send + Sync>),
+// }
 
 impl Error {
-    pub(crate) fn new_other(error: impl StdError + 'static) -> Self {
-        Self::Other(Box::new(error))
+    pub(crate) fn new(kind: ErrorKind, source: impl StdError + Send + Sync + 'static) -> Self {
+        let source: Box<dyn StdError + Send + Sync + 'static> = Box::new(source);
+
+        match source.downcast::<Self>() {
+            Ok(e) => *e,
+            Err(e) => Self {
+                kind,
+                source: Some(e),
+            },
+        }
     }
 
-    pub fn is_tls(&self) -> bool {
-        false
+    pub(crate) fn from_any<E>(error: E) -> Self
+    where
+        E: StdError + Send + Sync + 'static,
+    {
+        if TypeId::of::<E>() == TypeId::of::<Self>() {}
+        Self::new(ErrorKind::Unknown, error)
+    }
+
+    /// Get the kind of error this represents.
+    #[inline]
+    pub fn kind(&self) -> ErrorKind {
+        self.kind
+    }
+
+    // pub fn is_tls(&self) -> bool {
+    //     self.is_bad_client_certificate() || self.is_bad_server_certificate()
+    // }
+
+    // pub fn is_bad_client_certificate(&self) -> bool {
+    //     if let Self::Other(e) = self {
+    //         if let Some(e) = e.downcast_ref::<curl::Error>() {
+    //             return e.is_ssl_certproblem() || e.is_ssl_cacert_badfile();
+    //         }
+    //     }
+
+    //     false
+    // }
+
+    // pub fn is_bad_server_certificate(&self) -> bool {
+    //     if let Self::Other(e) = self {
+    //         if let Some(e) = e.downcast_ref::<curl::Error>() {
+    //             return e.is_peer_failed_verification() || e.is_ssl_cacert();
+    //         }
+    //     }
+
+    //     false
+    // }
+
+    // pub fn is_timeout(&self) -> bool {
+    //     match self {
+    //         Self::Io(e) => e.kind() == io::ErrorKind::TimedOut,
+    //         Self::Other(e) => {
+    //             if let Some(e) = e.downcast_ref::<curl::Error>() {
+    //                 e.is_operation_timedout()
+    //             } else {
+    //                 false
+    //             }
+    //         }
+    //         _ => false,
+    //     }
+    // }
+}
+
+impl StdError for Error {
+    fn source(&self) -> Option<&(dyn StdError + 'static)> {
+        self.source.as_ref().map(|e| &**e as _)
     }
 }
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{:?}: {}", self, Error::description(self))
+        let extra_description = self
+            .source
+            .as_ref()
+            .and_then(|e| e.downcast_ref::<curl::Error>())
+            .and_then(|e| e.extra_description());
+
+        if let Some(s) = extra_description {
+            write!(f, "{}: {}", self.kind, s)
+        } else {
+            write!(f, "{}", self.kind)
+        }
+        // match self {
+        //     Self::Aborted => f.write_str("request aborted unexpectedly"),
+        //     Self::BadClientCertificate(Some(ref e)) => f.write_str(e),
+        //     Self::BadServerCertificate(Some(ref e)) => f.write_str(e),
+        //     Self::ConnectFailed => f.write_str("failed to connect to the server"),
+        //     Self::CouldntResolveHost => f.write_str("couldn't resolve host name"),
+        //     Self::CouldntResolveProxy => f.write_str("couldn't resolve proxy host name"),
+        //     Self::InvalidContentEncoding(Some(ref e)) => write!(f, "invalid content encoding: {}", e),
+        //     Self::InvalidCredentials => f.write_str("credentials were rejected by the server"),
+        //     Self::InvalidHttpFormat(ref e) => e.fmt(f),
+        //     Self::InvalidUtf8 => f.write_str("bytes are not valid UTF-8"),
+        //     Self::Io(ref e) => e.fmt(f),
+        //     Self::NoResponse => f.write_str("server did not send a response"),
+        //     Self::RangeRequestUnsupported => f.write_str("server does not support or accept range requests"),
+        //     Self::RequestBodyError(Some(ref e)) => f.write_str(e),
+        //     Self::ResponseBodyError(Some(ref e)) => f.write_str(e),
+        //     Self::SSLConnectFailed(Some(ref e)) => f.write_str(e),
+        //     Self::SSLEngineError(Some(ref e)) => f.write_str(e),
+        //     Self::Timeout => f.write_str("request took longer than the configured timeout"),
+        //     Self::TooManyRedirects => f.write_str("max redirect limit exceeded"),
+        //     Self::Other(ref e) => e.fmt(f),
+        //     _ => f.write_str("unknown error"),
+        // }
     }
 }
 
-impl StdError for Error {
-    fn description(&self) -> &str {
-        match self {
-            Error::Aborted => "request aborted unexpectedly",
-            Error::BadClientCertificate(Some(ref e)) => e,
-            Error::BadServerCertificate(Some(ref e)) => e,
-            Error::ConnectFailed => "failed to connect to the server",
-            Error::CouldntResolveHost => "couldn't resolve host name",
-            Error::CouldntResolveProxy => "couldn't resolve proxy host name",
-            Error::Other(ref e) => e.description(),
-            Error::InvalidContentEncoding(Some(ref e)) => e,
-            Error::InvalidCredentials => "credentials were rejected by the server",
-            Error::InvalidHttpFormat(ref e) => e.description(),
-            Error::InvalidUtf8 => "bytes are not valid UTF-8",
-            Error::Io(ref e) => e.description(),
-            Error::NoResponse => "server did not send a response",
-            Error::RangeRequestUnsupported => "server does not support or accept range requests",
-            Error::RequestBodyError(Some(ref e)) => e,
-            Error::ResponseBodyError(Some(ref e)) => e,
-            Error::SSLConnectFailed(Some(ref e)) => e,
-            Error::SSLEngineError(Some(ref e)) => e,
-            Error::Timeout => "request took longer than the configured timeout",
-            Error::TooManyRedirects => "max redirect limit exceeded",
-            _ => "unknown error",
-        }
-    }
-
-    fn cause(&self) -> Option<&dyn StdError> {
-        match self {
-            Error::InvalidHttpFormat(e) => Some(e),
-            Error::Io(e) => Some(e),
-            _ => None,
-        }
+impl From<ErrorKind> for Error {
+    fn from(kind: ErrorKind) -> Self {
+        Self { kind, source: None }
     }
 }
 
 #[doc(hidden)]
 impl From<curl::Error> for Error {
     fn from(error: curl::Error) -> Error {
-        if error.is_ssl_certproblem() || error.is_ssl_cacert_badfile() {
-            Error::BadClientCertificate(error.extra_description().map(str::to_owned))
+        let kind = if error.is_ssl_certproblem() || error.is_ssl_cacert_badfile() {
+            ErrorKind::BadClientCertificate
         } else if error.is_peer_failed_verification() || error.is_ssl_cacert() {
-            Error::BadServerCertificate(error.extra_description().map(str::to_owned))
-        } else if error.is_couldnt_connect() {
-            Error::ConnectFailed
+            ErrorKind::BadServerCertificate
+        } else if error.is_couldnt_connect() || error.is_ssl_connect_error() {
+            ErrorKind::ConnectionFailed
         } else if error.is_couldnt_resolve_host() {
-            Error::CouldntResolveHost
+            ErrorKind::CouldntResolveHost
         } else if error.is_couldnt_resolve_proxy() {
-            Error::CouldntResolveProxy
+            ErrorKind::CouldntResolveProxy
         } else if error.is_bad_content_encoding() || error.is_conv_failed() {
-            Error::InvalidContentEncoding(error.extra_description().map(str::to_owned))
+            ErrorKind::InvalidContentEncoding
         } else if error.is_login_denied() {
-            Error::InvalidCredentials
+            ErrorKind::InvalidCredentials
         } else if error.is_got_nothing() {
-            Error::NoResponse
-        } else if error.is_range_error() {
-            Error::RangeRequestUnsupported
-        } else if error.is_read_error() || error.is_aborted_by_callback() {
-            Error::RequestBodyError(error.extra_description().map(str::to_owned))
-        } else if error.is_write_error() || error.is_partial_file() {
-            Error::ResponseBodyError(error.extra_description().map(str::to_owned))
-        } else if error.is_ssl_connect_error() {
-            Error::SSLConnectFailed(error.extra_description().map(str::to_owned))
+            ErrorKind::Protocol
+        } else if error.is_read_error()
+            || error.is_write_error()
+            || error.is_aborted_by_callback()
+            || error.is_partial_file()
+            || error.is_interface_failed()
+        {
+            ErrorKind::Io(std::io::ErrorKind::Other)
         } else if error.is_ssl_engine_initfailed()
             || error.is_ssl_engine_notfound()
             || error.is_ssl_engine_setfailed()
         {
-            Error::SSLEngineError(error.extra_description().map(str::to_owned))
+            ErrorKind::TlsEngineError
         } else if error.is_operation_timedout() {
-            Error::Timeout
+            ErrorKind::Timeout
         } else if error.is_too_many_redirects() {
-            Error::TooManyRedirects
+            ErrorKind::TooManyRedirects
         } else {
-            Error::new_other(error)
+            ErrorKind::Unknown
+        };
+
+        Self::new(kind, error)
+    }
+}
+
+impl From<io::Error> for Error {
+    fn from(error: io::Error) -> Self {
+        // If this I/O error is just a wrapped Isahc error, then unwrap it.
+        if let Some(inner) = error.get_ref() {
+            if inner.is::<Self>() {
+                return *error.into_inner().unwrap().downcast().unwrap();
+            }
         }
+
+        Self::new(
+            match error.kind() {
+                // io::ErrorKind::ConnectionRefused => Error::ConnectFailed,
+                io::ErrorKind::TimedOut => ErrorKind::Timeout,
+                kind => ErrorKind::Io(kind),
+            },
+            error,
+        )
+    }
+}
+
+impl From<Error> for io::Error {
+    fn from(mut error: Error) -> Self {
+        // If this error was directly created from an IO error, return it
+        // directly.
+        if matches!(error.kind, ErrorKind::Io(_)) {
+            if let Some(source) = error.source.take() {
+                match source.downcast() {
+                    Ok(e) => return *e,
+                    Err(e) => error.source = Some(e),
+                }
+            }
+        }
+
+        let kind = match error.kind {
+            ErrorKind::ConnectionFailed => io::ErrorKind::ConnectionRefused,
+            ErrorKind::Timeout => io::ErrorKind::TimedOut,
+            _ => io::ErrorKind::Other,
+        };
+
+        Self::new(kind, error)
     }
 }
 
 #[doc(hidden)]
 impl From<curl::MultiError> for Error {
     fn from(error: curl::MultiError) -> Error {
-        Error::new_other(error)
+        Self::new(if error.is_bad_socket() {
+            ErrorKind::Io(io::ErrorKind::BrokenPipe)
+        } else {
+            ErrorKind::Unknown
+        }, error)
     }
 }
 
 #[doc(hidden)]
 impl From<http::Error> for Error {
     fn from(error: http::Error) -> Error {
-        Error::InvalidHttpFormat(error)
-    }
-}
-
-#[doc(hidden)]
-impl From<io::Error> for Error {
-    fn from(error: io::Error) -> Error {
-        match error.kind() {
-            io::ErrorKind::ConnectionRefused => Error::ConnectFailed,
-            io::ErrorKind::TimedOut => Error::Timeout,
-            _ => Error::Io(error),
-        }
-    }
-}
-
-#[doc(hidden)]
-impl From<Error> for io::Error {
-    fn from(error: Error) -> io::Error {
-        match error {
-            Error::ConnectFailed => io::ErrorKind::ConnectionRefused.into(),
-            Error::Io(e) => e,
-            Error::Timeout => io::ErrorKind::TimedOut.into(),
-            e => io::Error::new(io::ErrorKind::Other, e),
-        }
-    }
-}
-
-#[doc(hidden)]
-impl From<std::string::FromUtf8Error> for Error {
-    fn from(_: std::string::FromUtf8Error) -> Error {
-        Error::InvalidUtf8
-    }
-}
-
-#[doc(hidden)]
-impl From<std::str::Utf8Error> for Error {
-    fn from(_: std::str::Utf8Error) -> Error {
-        Error::InvalidUtf8
+        Self::new(ErrorKind::Protocol, error)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -350,6 +350,8 @@ impl From<curl::Error> for Error {
             } else if error.is_got_nothing()
                 || error.is_http2_error()
                 || error.is_http2_stream_error()
+                || error.is_unsupported_protocol()
+                || error.code() == curl_sys::CURLE_FTP_WEIRD_SERVER_REPLY
             {
                 ErrorKind::ProtocolViolation
             } else if error.is_send_error()

--- a/src/error.rs
+++ b/src/error.rs
@@ -196,9 +196,7 @@ impl Error {
     /// Returns true if this is an error likely related to network failures.
     pub fn is_network(&self) -> bool {
         match self.kind() {
-            ErrorKind::ConnectionFailed
-            | ErrorKind::Io
-            | ErrorKind::NameResolution => true,
+            ErrorKind::ConnectionFailed | ErrorKind::Io | ErrorKind::NameResolution => true,
             _ => false,
         }
     }
@@ -206,9 +204,9 @@ impl Error {
     /// Returns true if this error was likely the fault of the server.
     pub fn is_server(&self) -> bool {
         match self.kind() {
-            ErrorKind::BadServerCertificate
-            | ErrorKind::Protocol
-            | ErrorKind::TooManyRedirects => true,
+            ErrorKind::BadServerCertificate | ErrorKind::Protocol | ErrorKind::TooManyRedirects => {
+                true
+            }
             _ => false,
         }
     }
@@ -300,6 +298,24 @@ impl From<Error> for io::Error {
         };
 
         Self::new(kind, error)
+    }
+}
+
+impl From<http::Error> for Error {
+    fn from(error: http::Error) -> Error {
+        Self::new(
+            if error.is::<http::header::InvalidHeaderName>()
+                || error.is::<http::header::InvalidHeaderValue>()
+                || error.is::<http::method::InvalidMethod>()
+                || error.is::<http::uri::InvalidUri>()
+                || error.is::<http::uri::InvalidUriParts>()
+            {
+                ErrorKind::InvalidRequest
+            } else {
+                ErrorKind::Unknown
+            },
+            error,
+        )
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -57,7 +57,7 @@ pub enum ErrorKind {
     /// The server made an unrecoverable HTTP protocol violation. This indicates
     /// a bug in the server. Retrying a request that returns this error is
     /// likely to produce the same error.
-    Protocol,
+    ProtocolViolation,
 
     /// Request processing could not continue because the client needed to
     /// re-send the request body, but was unable to rewind the body stream to
@@ -94,7 +94,7 @@ impl ErrorKind {
             Self::InvalidCredentials => Some("provided authentication credentials were rejected by the server"),
             Self::InvalidRequest => Some("invalid HTTP request"),
             Self::NameResolution => Some("failed to resolve host name"),
-            Self::Protocol => Some("the server made an unrecoverable HTTP protocol violation"),
+            Self::ProtocolViolation => Some("the server made an unrecoverable HTTP protocol violation"),
             Self::RequestBodyNotRewindable => Some("request body could not be re-sent because it is not rewindable"),
             Self::Timeout => Some("request or operation took longer than the configured timeout time"),
             Self::TlsEngine => Some("error ocurred in the secure socket engine"),
@@ -213,7 +213,7 @@ impl Error {
     /// Returns true if this error was likely the fault of the server.
     pub fn is_server(&self) -> bool {
         match self.kind() {
-            ErrorKind::BadServerCertificate | ErrorKind::Protocol | ErrorKind::TooManyRedirects => {
+            ErrorKind::BadServerCertificate | ErrorKind::ProtocolViolation | ErrorKind::TooManyRedirects => {
                 true
             }
             _ => false,
@@ -351,7 +351,7 @@ impl From<curl::Error> for Error {
                 || error.is_http2_error()
                 || error.is_http2_stream_error()
             {
-                ErrorKind::Protocol
+                ErrorKind::ProtocolViolation
             } else if error.is_send_error()
                 || error.is_recv_error()
                 || error.is_read_error()

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -153,14 +153,14 @@ impl RequestHandler {
         // Create a future that resolves when the handler receives the response
         // headers.
         let future = async move {
-            let builder = receiver.await.map_err(|_| Error::Aborted)??;
+            let builder = receiver.await.map_err(|e| Error::new(crate::error::ErrorKind::Unknown, e))??;
 
             let reader = ResponseBodyReader {
                 inner: response_body_reader,
                 shared,
             };
 
-            builder.body(reader).map_err(Error::InvalidHttpFormat)
+            builder.body(reader).map_err(|e| Error::new(crate::error::ErrorKind::Protocol, e))
         };
 
         (handler, future)

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -153,7 +153,7 @@ impl RequestHandler {
                 shared,
             };
 
-            builder.body(reader).map_err(|e| Error::new(crate::error::ErrorKind::Protocol, e))
+            builder.body(reader).map_err(|e| Error::new(crate::error::ErrorKind::ProtocolViolation, e))
         };
 
         (handler, future)

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -146,7 +146,7 @@ impl RequestHandler {
         // Create a future that resolves when the handler receives the response
         // headers.
         let future = async move {
-            let builder = receiver.recv_async().await.map_err(|_| Error::new(crate::error::ErrorKind::Unknown, e))??;
+            let builder = receiver.recv_async().await.map_err(|e| Error::new(crate::error::ErrorKind::Unknown, e))??;
 
             let reader = ResponseBodyReader {
                 inner: response_body_reader,

--- a/src/interceptor/context.rs
+++ b/src/interceptor/context.rs
@@ -22,18 +22,7 @@ impl<'a> Context<'a> {
                 interceptors: &self.interceptors[1..],
             };
 
-            match interceptor.intercept(request, inner_context).await {
-                Ok(response) => Ok(response),
-
-                // If the error is an Isahc error, return it directly.
-                Err(e) => match e.downcast::<Error>() {
-                    Ok(e) => Err(*e),
-
-                    // TODO: Introduce a new error variant for errors caused by an
-                    // interceptor. This is a temporary hack.
-                    Err(e) => Err(Error::Curl(e.to_string())),
-                },
-            }
+            interceptor.intercept(request, inner_context).await
         } else {
             self.invoker.invoke(request).await
         }

--- a/src/interceptor/mod.rs
+++ b/src/interceptor/mod.rs
@@ -71,7 +71,7 @@ macro_rules! interceptor {
 /// made in parallel.
 pub trait Interceptor: Send + Sync {
     /// The type of error returned by this interceptor.
-    type Err: Into<Box<dyn Error>>;
+    type Err: Error + Send + Sync + 'static;
 
     /// Intercept a request, returning a response.
     ///
@@ -87,7 +87,7 @@ pub type InterceptorFuture<'a, E> = BoxFuture<'a, Result<Response<Body>, E>>;
 pub fn from_fn<F, E>(f: F) -> InterceptorFn<F>
 where
     F: for<'a> private::AsyncFn2<Request<Body>, Context<'a>, Output = Result<Response<Body>, E>> + Send + Sync + 'static,
-    E: Into<Box<dyn Error>>,
+    E: Error + Send + Sync + 'static,
 {
     InterceptorFn(f)
 }
@@ -98,7 +98,7 @@ pub struct InterceptorFn<F>(F);
 
 impl<E, F> Interceptor for InterceptorFn<F>
 where
-    E: Into<Box<dyn Error>>,
+    E: Error + Send + Sync + 'static,
     F: for<'a> private::AsyncFn2<Request<Body>, Context<'a>, Output = Result<Response<Body>, E>> + Send + Sync + 'static,
 {
     type Err = E;

--- a/src/interceptor/mod.rs
+++ b/src/interceptor/mod.rs
@@ -55,7 +55,7 @@ macro_rules! interceptor {
         async fn interceptor(
             mut $request: $crate::http::Request<$crate::Body>,
             $ctx: $crate::interceptor::Context<'_>,
-        ) -> Result<$crate::http::Response<isahc::Body>, Box<dyn ::std::error::Error>> {
+        ) -> Result<$crate::http::Response<isahc::Body>, $crate::Error> {
             (move || async move {
                 $body
             })().await.map_err(Into::into)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,7 +131,7 @@
 //!
 //! ```toml
 //! [dependencies.isahc]
-//! version = "0.8"
+//! version = "0.9"
 //! features = ["psl"]
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -224,6 +224,9 @@ use http::{Request, Response};
 use once_cell::sync::Lazy;
 use std::convert::TryFrom;
 
+#[macro_use]
+mod macros;
+
 #[cfg(feature = "cookies")]
 pub mod cookies;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -230,7 +230,6 @@ pub mod cookies;
 mod agent;
 mod body;
 mod client;
-mod error;
 mod handler;
 mod headers;
 mod metrics;
@@ -241,6 +240,7 @@ mod task;
 mod text;
 
 pub mod auth;
+pub mod error;
 pub mod config;
 
 #[cfg(feature = "unstable-interceptors")]

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,23 @@
+/// Helper macro that allows you to attempt to downcast a generic type, as long
+/// as it is known to be `'static`.
+macro_rules! match_type {
+    {
+        $(
+            <$name:ident as $T:ty> => $branch:expr,
+        )*
+        $defaultName:ident => $defaultBranch:expr,
+    } => {{
+        match () {
+            $(
+                _ if ::std::any::Any::type_id(&$name) == ::std::any::TypeId::of::<$T>() => {
+                    #[allow(unsafe_code)]
+                    let $name: $T = unsafe {
+                        ::std::mem::transmute_copy::<_, $T>(&::std::mem::ManuallyDrop::new($name))
+                    };
+                    $branch
+                }
+            )*
+            _ => $defaultBranch,
+        }
+    }};
+}

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -114,7 +114,9 @@ impl Interceptor for RedirectInterceptor {
 
                     // Update the request to point to the new URI.
                     effective_uri = location.clone();
-                    request = request_builder.uri(location).body(request_body)?;
+                    request = request_builder.uri(location)
+                        .body(request_body)
+                        .map_err(|e| Error::new(ErrorKind::InvalidRequest, e))?;
                     redirect_count += 1;
                 }
 

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,10 +1,10 @@
 use crate::{
     config::RedirectPolicy,
+    error::{Error, ErrorKind},
     handler::RequestBody,
     interceptor::{Context, Interceptor, InterceptorFuture},
     request::RequestExt,
     Body,
-    Error,
 };
 use http::{Request, Uri};
 
@@ -63,7 +63,7 @@ impl Interceptor for RedirectInterceptor {
 
                 // If we've reached the limit, return an error as requested.
                 if redirect_count >= limit {
-                    return Err(Error::TooManyRedirects);
+                    return Err(ErrorKind::TooManyRedirects.into());
                 }
 
                 // Set referer header.
@@ -95,7 +95,7 @@ impl Interceptor for RedirectInterceptor {
                 // There's not really a good way of handling this gracefully, so
                 // we just return an error so that the user knows about it.
                 if !request_body.reset() {
-                    return Err(Error::RequestBodyError(Some(String::from("could not follow redirect because request body is not rewindable"))));
+                    return Err(ErrorKind::RequestBodyNotRewindable.into());
                 }
 
                 let request = request_builder.uri(redirect_uri)

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -4,7 +4,7 @@ use crate::{
     handler::RequestBody,
     interceptor::{Context, Interceptor, InterceptorFuture},
     request::RequestExt,
-    Body, Error,
+    Body,
 };
 use http::{Request, Response, Uri};
 use std::convert::TryFrom;

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,10 +1,10 @@
 //! Helpers for working with tasks and futures.
 
-use crate::Error;
 use crossbeam_utils::sync::{Parker, Unparker};
 use futures_util::{pin_mut, task::ArcWake};
 use std::{
     future::Future,
+    io,
     net::{SocketAddr, UdpSocket},
     sync::Arc,
     task::{Context, Poll, Waker},
@@ -79,7 +79,7 @@ pub(crate) struct UdpWaker {
 
 impl UdpWaker {
     /// Create a waker by connecting to the wake address of an UDP server.
-    pub(crate) fn connect(addr: SocketAddr) -> Result<Self, Error> {
+    pub(crate) fn connect(addr: SocketAddr) -> io::Result<Self> {
         let socket = UdpSocket::bind("127.0.0.1:0")?;
         socket.connect(addr)?;
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -1,10 +1,6 @@
 //! Helpers for working with tasks and futures.
 
-use crate::Error;
-use crossbeam_utils::sync::{Parker, Unparker};
-use futures_util::{pin_mut, task::ArcWake};
 use std::{
-    future::Future,
     io,
     net::{SocketAddr, UdpSocket},
     task::Waker,

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -126,7 +126,7 @@ fn unknown_content_encoding_returns_error() {
         .send();
 
     match result {
-        Err(isahc::Error::InvalidContentEncoding(_)) => {}
+        Err(e) if e.kind() == isahc::error::ErrorKind::InvalidContentEncoding => {}
         _ => panic!("expected unknown encoding error, instead got {:?}", result),
     };
 

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -225,7 +225,7 @@ fn redirect_non_rewindable_body_returns_error() {
         .unwrap()
         .send();
 
-    assert_matches!(result, Err(e) if e.kind() == isahc::error::ErrorKind::RequestBodyNotRewindable);
+    assert_matches!(result, Err(e) if e == isahc::error::ErrorKind::RequestBodyNotRewindable);
     assert_eq!(m1.request().method, "POST");
 }
 
@@ -245,7 +245,7 @@ fn redirect_limit_is_respected() {
         .send();
 
     // Request should error with too many redirects.
-    assert_matches!(result, Err(e) if e.kind() == isahc::error::ErrorKind::TooManyRedirects);
+    assert_matches!(result, Err(e) if e == isahc::error::ErrorKind::TooManyRedirects);
 
     // After request (limit + 1) that returns a redirect should error.
     assert_eq!(m.requests().len(), 6);

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -165,7 +165,7 @@ fn redirect_non_rewindable_body_returns_error() {
         .unwrap()
         .send();
 
-    assert!(matches!(result, Err(isahc::Error::RequestBodyError(_))));
+    assert!(matches!(result, Err(e) if e.kind() == isahc::error::ErrorKind::RequestBodyNotRewindable));
     assert_eq!(m1.request().method, "POST");
 }
 
@@ -185,10 +185,7 @@ fn redirect_limit_is_respected() {
         .send();
 
     // Request should error with too many redirects.
-    assert!(match result {
-        Err(isahc::Error::TooManyRedirects) => true,
-        _ => false,
-    });
+    assert!(matches!(result, Err(e) if e.kind() == isahc::error::ErrorKind::TooManyRedirects));
 
     // After request (limit + 1) that returns a redirect should error.
     assert_eq!(m.requests().len(), 6);

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -245,7 +245,7 @@ fn redirect_limit_is_respected() {
         .send();
 
     // Request should error with too many redirects.
-    assert!(matches!(result, Err(e) if e.kind() == isahc::error::ErrorKind::TooManyRedirects));
+    assert_matches!(result, Err(e) if e.kind() == isahc::error::ErrorKind::TooManyRedirects);
 
     // After request (limit + 1) that returns a redirect should error.
     assert_eq!(m.requests().len(), 6);

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -21,7 +21,7 @@ fn request_errors_if_read_timeout_is_reached() {
         .send();
 
     // Client should time-out.
-    assert_matches!(result, Err(e) if e.kind() == isahc::error::ErrorKind::Timeout);
+    assert_matches!(result, Err(e) if e == isahc::error::ErrorKind::Timeout);
 
     assert_eq!(m.requests().len(), 1);
 }

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -17,13 +17,8 @@ fn request_errors_if_read_timeout_is_reached() {
         .unwrap()
         .send();
 
-    // Client should time-out.
-    match result {
-        Err(isahc::Error::Timeout) => {}
-        e => {
-            panic!("expected timeout error, got {:?}", e);
-        }
-    }
+    // Client should time out.
+    assert!(matches!(result, Err(e) if e.kind() == isahc::error::ErrorKind::Timeout));
 
     assert_eq!(m.requests().len(), 1);
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,13 +1,13 @@
 macro_rules! assert_matches {
-    ($value:expr, $pattern:pat) => {{
+    ($value:expr, $($pattern:tt)+) => {{
         match $value {
-            $pattern => {},
+            $($pattern)* => {},
             value => panic!(
                 "assertion failed: `{}` matches `{}`\n  value: `{:?}`",
                 stringify!($value),
-                stringify!($pattern),
+                stringify!($($pattern)*),
                 value,
             ),
         }
-    }}
+    }};
 }


### PR DESCRIPTION
Update `isahc::Error` to support taking new variants in a backwards-compatible way, as well as hold more error sources when an error is caused by another.

Note that this is the first 1.0 breaking change to land on `master`. If 0.9 needs a patch fix in the future, we'll have to make a 0.9.x branch for it.

Fixes #182.