### PR TITLE
Pin MSRV to 1.41

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.45.0"
+          toolchain: "1.41.1"
           default: true
 
       - run: cargo test --features cookies,psl,spnego,unstable-interceptors

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,7 +97,7 @@ static_assertions = "1.1"
 structopt = "0.3"
 tempfile = "3.1"
 test-case = "1.0"
-tracing-subscriber = "0.2"
+tracing-subscriber = "=0.2.12"
 
 [dev-dependencies.testserver]
 path = "testserver"

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ _Formerly known as [chttp]._
 [![Crates.io](https://img.shields.io/crates/v/isahc.svg)](https://crates.io/crates/isahc)
 [![Documentation](https://docs.rs/isahc/badge.svg)][documentation]
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
+[![Minimum supported Rust version](https://img.shields.io/badge/rustc-1.41+-yellow.svg)](#minimum-supported-rust-version)
 [![Crates.io downloads](https://img.shields.io/crates/d/isahc)](https://crates.io/crates/isahc)
 ![Maintenance](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 [![Build](https://github.com/sagebind/isahc/workflows/ci/badge.svg)](https://github.com/sagebind/isahc/actions)
@@ -84,9 +85,9 @@ Install via Cargo by adding to your `Cargo.toml` file:
 isahc = "0.9"
 ```
 
-### Supported Rust versions
+## Minimum supported Rust version
 
-The current release is only guaranteed to work with the latest stable Rust compiler. When Isahc reaches version `1.0`, a more conservative policy will be adopted.
+The minimum supported Rust version (or _MSRV_) for Isahc is **stable Rust 1.41 or greater**, meaning we only guarantee that Isahc will compile if you use a rustc version of at least 1.41. It might compile with older versions but that could change at any time.
 
 ## Project goals
 

--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ isahc = "0.9"
 
 The minimum supported Rust version (or _MSRV_) for Isahc is **stable Rust 1.41 or greater**, meaning we only guarantee that Isahc will compile if you use a rustc version of at least 1.41. It might compile with older versions but that could change at any time.
 
+This version is explicitly tested in CI and may only be bumped in new minor versions. Any changes to the supported minimum version will be called out in the release notes.
+
 ## Project goals
 
 - Create an ergonomic and innovative HTTP client API that is easy for beginners to use, and flexible for advanced uses.

--- a/src/config/dial.rs
+++ b/src/config/dial.rs
@@ -135,12 +135,14 @@ impl FromStr for Dialer {
         }
 
         #[cfg(unix)]
-        if s.starts_with("unix:") {
-            // URI paths are always absolute.
-            let mut path = std::path::PathBuf::from("/");
-            path.push(&s[5..].trim_start_matches("/"));
+        {
+            if s.starts_with("unix:") {
+                // URI paths are always absolute.
+                let mut path = std::path::PathBuf::from("/");
+                path.push(&s[5..].trim_start_matches("/"));
 
-            return Ok(Self(Inner::UnixSocket(path)));
+                return Ok(Self(Inner::UnixSocket(path)));
+            }
         }
 
         Err(DialerParseError(()))

--- a/src/cookies/cookie.rs
+++ b/src/cookies/cookie.rs
@@ -248,7 +248,10 @@ fn parse_cookie_value(mut bytes: &[u8]) -> Result<&str, ParseError> {
 fn is_valid_cookie_value(bytes: &[u8]) -> bool {
     bytes
         .iter()
-        .all(|&byte| matches!(byte, 0x21 | 0x23..=0x2B | 0x2D..=0x3A | 0x3C..=0x5B | 0x5D..=0x7E))
+        .all(|&byte| match byte {
+            0x21 | 0x23..=0x2B | 0x2D..=0x3A | 0x3C..=0x5B | 0x5D..=0x7E => true,
+            _ => false,
+        })
 }
 
 // https://tools.ietf.org/html/rfc2616#section-2.2

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -5,6 +5,9 @@ use isahc::{
 use test_case::test_case;
 use testserver::mock;
 
+#[macro_use]
+mod utils;
+
 #[test]
 fn response_301_no_follow() {
     let m = mock! {
@@ -222,7 +225,7 @@ fn redirect_non_rewindable_body_returns_error() {
         .unwrap()
         .send();
 
-    assert!(matches!(result, Err(isahc::Error::RequestBodyError(_))));
+    assert_matches!(result, Err(isahc::Error::RequestBodyError(_)));
     assert_eq!(m1.request().method, "POST");
 }
 

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -2,6 +2,9 @@ use isahc::prelude::*;
 use std::{io::{self, Cursor, Read}, thread, time::Duration};
 use testserver::mock;
 
+#[macro_use]
+mod utils;
+
 /// Issue #3
 #[test]
 fn request_errors_if_read_timeout_is_reached() {
@@ -18,7 +21,7 @@ fn request_errors_if_read_timeout_is_reached() {
         .send();
 
     // Client should time-out.
-    assert!(matches!(result, Err(isahc::Error::Timeout)));
+    assert_matches!(result, Err(isahc::Error::Timeout));
 
     assert_eq!(m.requests().len(), 1);
 }

--- a/tests/utils/mod.rs
+++ b/tests/utils/mod.rs
@@ -1,0 +1,13 @@
+macro_rules! assert_matches {
+    ($value:expr, $pattern:pat) => {{
+        match $value {
+            $pattern => {},
+            value => panic!(
+                "assertion failed: `{}` matches `{}`\n  value: `{:?}`",
+                stringify!($value),
+                stringify!($pattern),
+                value,
+            ),
+        }
+    }}
+}


### PR DESCRIPTION
1.41 is the version on Debian stable (a common distribution channel) and supports basically everything that we require. Only a few small changes were required to get it to compile with this version.

Fixes #219.