### PR TITLE
Remove bytes dependency & update Body constructors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,6 @@ text-decoding = ["encoding_rs", "mime"]
 unstable-interceptors = []
 
 [dependencies]
-bytes = "0.5"
 crossbeam-utils = "0.8"
 curl = "0.4.34"
 curl-sys = "0.4.37"

--- a/src/body.rs
+++ b/src/body.rs
@@ -59,11 +59,11 @@ impl Body {
     /// ```
     /// use isahc::Body;
     ///
-    /// // Create a body from a string.
-    /// let body = Body::from_static_bytes("hello world");
+    /// // Create a body from a static string.
+    /// let body = Body::from_bytes_static("hello world");
     /// ```
     #[inline]
-    pub fn from_static_bytes<B>(bytes: B) -> Self
+    pub fn from_bytes_static<B>(bytes: B) -> Self
     where
         B: AsRef<[u8]> + 'static
     {

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -217,7 +217,7 @@ fn redirect_non_rewindable_body_returns_error() {
     };
 
     // Create a streaming body of unknown size.
-    let upload_stream = Body::from_reader(Body::from_bytes(b"hello world"));
+    let upload_stream = Body::from_reader(Body::from_static_bytes(b"hello world"));
 
     let result = Request::post(m1.url())
         .redirect_policy(RedirectPolicy::Follow)

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -217,7 +217,7 @@ fn redirect_non_rewindable_body_returns_error() {
     };
 
     // Create a streaming body of unknown size.
-    let upload_stream = Body::from_reader(Body::from_static_bytes(b"hello world"));
+    let upload_stream = Body::from_reader(Body::from_bytes_static(b"hello world"));
 
     let result = Request::post(m1.url())
         .redirect_policy(RedirectPolicy::Follow)


### PR DESCRIPTION
Remove bytes as a direct dependency, as our small usage does not really justify its inclusion. In addition, update the constructor methods for `Body` to reflect this change. These changes are minor but breaking, but encourage using the `From` traits more so as to reduce copying when possible.