### PR TITLE
Split sync and async body into distinct types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,6 @@ features = ["std", "std-future"]
 [dev-dependencies]
 env_logger = "0.8"
 flate2 = "1.0"
-futures = "0.3"
 indicatif = "0.15"
 rayon = "1"
 static_assertions = "1.1"

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -4,7 +4,7 @@
 use isahc::prelude::*;
 
 fn main() -> Result<(), isahc::Error> {
-    futures::executor::block_on(async {
+    futures_lite::future::block_on(async {
         let mut response = isahc::get_async("http://example.org").await?;
 
         println!("Status: {}", response.status());

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), isahc::Error> {
 
         println!("Status: {}", response.status());
         println!("Headers:\n{:?}", response.headers());
-        println!("Body: {}", response.text_async().await?);
+        println!("Body: {}", response.text().await?);
 
         Ok(())
     })

--- a/examples/stream_cancellation.rs
+++ b/examples/stream_cancellation.rs
@@ -2,7 +2,7 @@
 //! a program that aborts downloading a response if it contains the byte `0x3F`
 //! (ASCII "?").
 
-use futures::{executor::block_on, io::AsyncReadExt};
+use futures_lite::{future::block_on, io::AsyncReadExt};
 
 fn main() -> Result<(), isahc::Error> {
     block_on(async {

--- a/examples/upload_file.rs
+++ b/examples/upload_file.rs
@@ -1,0 +1,19 @@
+use isahc::prelude::*;
+use std::fs::File;
+
+fn main() -> Result<(), isahc::Error> {
+    env_logger::init();
+    let client = HttpClient::new()?;
+
+    let file = File::open(file!())?;
+    let request = isahc::http::Request::put("https://httpbin.org/put")
+        .body(file)?;
+
+    let mut response = client.send_sync(request)?;
+
+    println!("Status: {}", response.status());
+    println!("Headers: {:#?}", response.headers());
+    print!("{}", response.text()?);
+
+    Ok(())
+}

--- a/examples/upload_file.rs
+++ b/examples/upload_file.rs
@@ -2,14 +2,8 @@ use isahc::prelude::*;
 use std::fs::File;
 
 fn main() -> Result<(), isahc::Error> {
-    env_logger::init();
-    let client = HttpClient::new()?;
-
     let file = File::open(file!())?;
-    let request = isahc::http::Request::put("https://httpbin.org/put")
-        .body(file)?;
-
-    let mut response = client.send(request)?;
+    let mut response = isahc::put("https://httpbin.org/put", file)?;
 
     println!("Status: {}", response.status());
     println!("Headers: {:#?}", response.headers());

--- a/examples/upload_file.rs
+++ b/examples/upload_file.rs
@@ -1,10 +1,23 @@
+//! Sample program that demonstrates how to upload a file using a `PUT` request.
+//! Since 1.0, you can use a `File` as the request body directly, or anything
+//! implementing `Read`, when using the synchronous APIs.
+//!
+//! If using the asynchronous APIs, you will need an asynchronous version of
+//! `File` such as the one provided by [`async-fs`](https://docs.rs/async-fs).
+//! Isahc does not provide an implementation for you.
+
 use isahc::prelude::*;
 use std::fs::File;
 
 fn main() -> Result<(), isahc::Error> {
+    // We're opening the source code file you are looking at right now for
+    // reading.
     let file = File::open(file!())?;
+
+    // Perform the upload.
     let mut response = isahc::put("https://httpbin.org/put", file)?;
 
+    // Print interesting info from the response.
     println!("Status: {}", response.status());
     println!("Headers: {:#?}", response.headers());
     print!("{}", response.text()?);

--- a/examples/upload_file.rs
+++ b/examples/upload_file.rs
@@ -9,7 +9,7 @@ fn main() -> Result<(), isahc::Error> {
     let request = isahc::http::Request::put("https://httpbin.org/put")
         .body(file)?;
 
-    let mut response = client.send_sync(request)?;
+    let mut response = client.send(request)?;
 
     println!("Status: {}", response.status());
     println!("Headers: {:#?}", response.headers());

--- a/src/agent.rs
+++ b/src/agent.rs
@@ -336,7 +336,7 @@ impl AgentContext {
         let handle = self.requests.remove(token);
         let mut handle = self.multi.remove2(handle)?;
 
-        handle.get_mut().on_result(result);
+        handle.get_mut().set_result(result.map_err(Error::from));
 
         Ok(())
     }

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -152,6 +152,13 @@ impl AsyncBody {
         }
     }
 
+    /// Turn this asynchronous body into a synchronous one. This is how the
+    /// response body is implemented for the synchronous API.
+    ///
+    /// We do not expose this publicly because while we know that this
+    /// implementation works for the bodies _we_ create, it may not work
+    /// generally if the underlying reader only supports blocking under a
+    /// specific runtime.
     pub(crate) fn into_sync(self) -> sync::Body {
         match self.0 {
             Inner::Empty => sync::Body::from_bytes_static(b""),

--- a/src/body/sync.rs
+++ b/src/body/sync.rs
@@ -298,4 +298,39 @@ mod tests {
         assert!(!body.is_empty());
         assert_eq!(body.len(), Some(0));
     }
+
+    #[test]
+    fn reader_with_unknown_length() {
+        let body = Body::from_reader(std::io::empty());
+
+        assert!(!body.is_empty());
+        assert_eq!(body.len(), None);
+    }
+
+    #[test]
+    fn reader_with_known_length() {
+        let body = Body::from_reader_sized(std::io::empty(), 0);
+
+        assert!(!body.is_empty());
+        assert_eq!(body.len(), Some(0));
+    }
+
+    #[test]
+    fn reset_memory_body() {
+        let mut body = Body::from("hello world");
+        let mut buf = String::new();
+
+        assert_eq!(body.read_to_string(&mut buf).unwrap(), 11);
+        assert_eq!(buf, "hello world");
+        assert!(body.reset());
+        assert_eq!(body.read_to_string(&mut buf).unwrap(), 11);
+        assert_eq!(buf, "hello worldhello world");
+    }
+
+    #[test]
+    fn cannot_reset_reader() {
+        let mut body = Body::from_reader(std::io::empty());
+
+        assert_eq!(body.reset(), false);
+    }
 }

--- a/src/body/sync.rs
+++ b/src/body/sync.rs
@@ -20,25 +20,39 @@ use std::{
 pub struct Body(Inner);
 
 enum Inner {
+    Empty,
     Buffer(Cursor<Cow<'static, [u8]>>),
     Reader(Box<dyn Read + Send + Sync>, Option<u64>),
 }
 
 impl Body {
-    pub fn from_reader<R>(reader: R) -> Self
-    where
-        R: Read + Send + Sync + 'static,
-    {
-        Self(Inner::Reader(Box::new(reader), None))
+    /// Create a new empty body.
+    ///
+    /// An empty body represents the *absence* of a body, which is semantically
+    /// different than the presence of a body of zero length.
+    pub const fn empty() -> Self {
+        Self(Inner::Empty)
     }
 
-    pub fn from_reader_sized<R>(reader: R, length: u64) -> Self
-    where
-        R: Read + Send + Sync + 'static,
-    {
-        Self(Inner::Reader(Box::new(reader), Some(length)))
-    }
-
+    /// Create a new body from a potentially static byte buffer.
+    ///
+    /// The body will have a known length equal to the number of bytes given.
+    ///
+    /// This will try to prevent a copy if the type passed in can be re-used,
+    /// otherwise the buffer will be copied first. This method guarantees to not
+    /// require a copy for the following types:
+    ///
+    /// - `&'static [u8]`
+    /// - `&'static str`
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use isahc::Body;
+    ///
+    /// // Create a body from a static string.
+    /// let body = Body::from_bytes_static("hello world");
+    /// ```
     #[inline]
     pub fn from_bytes_static<B>(bytes: B) -> Self
     where
@@ -52,15 +66,74 @@ impl Body {
         }
     }
 
+    /// Create a streaming body that reads from the given reader.
+    ///
+    /// The body will have an unknown length. When used as a request body,
+    /// [chunked transfer
+    /// encoding](https://tools.ietf.org/html/rfc7230#section-4.1) might be used
+    /// to send the request.
+    pub fn from_reader<R>(reader: R) -> Self
+    where
+        R: Read + Send + Sync + 'static,
+    {
+        Self(Inner::Reader(Box::new(reader), None))
+    }
+
+    /// Create a streaming body with a known length.
+    ///
+    /// If the size of the body is known in advance, such as with a file, then
+    /// this function can be used to create a body that can determine its
+    /// `Content-Length` while still reading the bytes asynchronously.
+    ///
+    /// Giving a value for `length` that doesn't actually match how much data
+    /// the reader will produce may result in errors when sending the body in a
+    /// request.
+    pub fn from_reader_sized<R>(reader: R, length: u64) -> Self
+    where
+        R: Read + Send + Sync + 'static,
+    {
+        Self(Inner::Reader(Box::new(reader), Some(length)))
+    }
+
+    /// Report if this body is empty.
+    ///
+    /// This is not necessarily the same as checking for `self.len() ==
+    /// Some(0)`. Since HTTP message bodies are optional, there is a semantic
+    /// difference between the absence of a body and the presence of a
+    /// zero-length body. This method will only return `true` for the former.
+    pub fn is_empty(&self) -> bool {
+        match self.0 {
+            Inner::Empty => true,
+            _ => false,
+        }
+    }
+
+    /// Get the size of the body, if known.
+    ///
+    /// The value reported by this method is used to set the `Content-Length`
+    /// for outgoing requests.
+    ///
+    /// When coming from a response, this method will report the value of the
+    /// `Content-Length` response header if present. If this method returns
+    /// `None` then there's a good chance that the server used something like
+    /// chunked transfer encoding to send the response body.
+    ///
+    /// Since the length may be determined totally separately from the actual
+    /// bytes, even if a value is returned it should not be relied on as always
+    /// being accurate, and should be treated as a "hint".
     pub fn len(&self) -> Option<u64> {
         match &self.0 {
+            Inner::Empty => Some(0),
             Inner::Buffer(bytes) => Some(bytes.get_ref().len() as u64),
             Inner::Reader(_, len) => *len,
         }
     }
 
+    /// If this body is repeatable, reset the body stream back to the start of
+    /// the content. Returns `false` if the body cannot be reset.
     pub fn reset(&mut self) -> bool {
         match &mut self.0 {
+            Inner::Empty => true,
             Inner::Buffer(cursor) => {
                 cursor.set_position(0);
                 true
@@ -82,6 +155,7 @@ impl Body {
     /// blocking fashion.
     pub(crate) fn into_async(self) -> (AsyncBody, Option<Writer>) {
         match self.0 {
+            Inner::Empty => (AsyncBody::empty(), None),
             Inner::Buffer(cursor) => (AsyncBody::from_bytes_static(cursor.into_inner()), None),
             Inner::Reader(reader, len) => {
                 let (pipe_reader, writer) = pipe();
@@ -102,15 +176,22 @@ impl Body {
 impl Read for Body {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
         match &mut self.0 {
+            Inner::Empty => Ok(0),
             Inner::Buffer(cursor) => cursor.read(buf),
             Inner::Reader(reader, _) => reader.read(buf),
         }
     }
 }
 
+impl Default for Body {
+    fn default() -> Self {
+        Self::empty()
+    }
+}
+
 impl From<()> for Body {
     fn from(_: ()) -> Self {
-        Self::from("")
+        Self::empty()
     }
 }
 
@@ -193,5 +274,28 @@ impl Writer {
 
             self.writer.write_all(&buf[..len]).await?;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    static_assertions::assert_impl_all!(Body: Send, Sync);
+
+    #[test]
+    fn empty_body() {
+        let body = Body::empty();
+
+        assert!(body.is_empty());
+        assert_eq!(body.len(), Some(0));
+    }
+
+    #[test]
+    fn zero_length_body() {
+        let body = Body::from(vec![]);
+
+        assert!(!body.is_empty());
+        assert_eq!(body.len(), Some(0));
     }
 }

--- a/src/body/sync.rs
+++ b/src/body/sync.rs
@@ -1,0 +1,154 @@
+use futures_lite::{future::yield_now, io::AsyncWriteExt};
+use sluice::pipe::{pipe, PipeWriter};
+use std::{
+    borrow::Cow,
+    fs::File,
+    io::{Cursor, ErrorKind, Read, Result},
+};
+
+/// Synchronous streaming body
+pub struct Body(Repr);
+
+enum Repr {
+    Buffer(Cursor<Cow<'static, [u8]>>),
+    Reader(Box<dyn Read + Send + Sync>, Option<u64>),
+}
+
+impl Body {
+    pub fn from_reader<R>(reader: R) -> Self
+    where
+        R: Read + Send + Sync + 'static,
+    {
+        Self(Repr::Reader(Box::new(reader), None))
+    }
+
+    pub fn from_reader_sized<R>(reader: R, length: u64) -> Self
+    where
+        R: Read + Send + Sync + 'static,
+    {
+        Self(Repr::Reader(Box::new(reader), Some(length)))
+    }
+
+    #[inline]
+    pub fn from_bytes_static<B>(bytes: B) -> Self
+    where
+        B: AsRef<[u8]> + 'static
+    {
+        match_type! {
+            <bytes as Cursor<Cow<'static, [u8]>>> => Self(Repr::Buffer(bytes)),
+            <bytes as Vec<u8>> => Self::from(bytes),
+            <bytes as String> => Self::from(bytes.into_bytes()),
+            bytes => Self::from(bytes.as_ref().to_vec()),
+        }
+    }
+
+    pub fn len(&self) -> Option<u64> {
+        match &self.0 {
+            Repr::Buffer(bytes) => Some(bytes.get_ref().len() as u64),
+            Repr::Reader(_, len) => *len,
+        }
+    }
+
+    pub fn reset(&mut self) -> bool {
+        match &mut self.0 {
+            Repr::Buffer(cursor) => {
+                cursor.set_position(0);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    pub(crate) fn into_async(self) -> (super::Body, Option<Writer>) {
+        match self.0 {
+            Repr::Buffer(cursor) => (super::Body::from_bytes_static(cursor.into_inner()), None),
+            Repr::Reader(reader, len) => {
+                // Create an intermediate pipe for writing this request body.
+                let (pipe_reader, writer) = pipe();
+
+                (
+                    if let Some(len) = len {
+                        super::Body::from_reader_sized(pipe_reader, len)
+                    } else {
+                        super::Body::from_reader(pipe_reader)
+                    },
+                    Some(Writer { reader, writer }),
+                )
+            }
+        }
+    }
+}
+
+impl Read for Body {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        match &mut self.0 {
+            Repr::Buffer(cursor) => cursor.read(buf),
+            Repr::Reader(reader, _) => reader.read(buf),
+        }
+    }
+}
+
+impl From<Vec<u8>> for Body {
+    fn from(body: Vec<u8>) -> Self {
+        Self(Repr::Buffer(Cursor::new(Cow::Owned(body))))
+    }
+}
+
+impl From<&'_ [u8]> for Body {
+    fn from(body: &[u8]) -> Self {
+        body.to_vec().into()
+    }
+}
+
+impl From<String> for Body {
+    fn from(body: String) -> Self {
+        body.into_bytes().into()
+    }
+}
+
+impl From<&'_ str> for Body {
+    fn from(body: &str) -> Self {
+        body.as_bytes().into()
+    }
+}
+
+impl From<File> for Body {
+    fn from(file: File) -> Self {
+        if let Ok(metadata) = file.metadata() {
+            Self::from_reader_sized(file, metadata.len())
+        } else {
+            Self::from_reader(file)
+        }
+    }
+}
+
+pub(crate) struct Writer {
+    reader: Box<dyn Read + Send + Sync>,
+    writer: PipeWriter,
+}
+
+impl Writer {
+    /// Write the response body from the synchronous reader.
+    ///
+    /// While this function is async, it isn't a well-behaved one as it blocks
+    /// frequently while reading from the request body reader. As long as this
+    /// method is invoked in a controlled environment within a thread dedicated
+    /// to blocking operations, this is OK.
+    pub(crate) async fn write(&mut self) -> Result<()> {
+        let mut buf = [0; 8192];
+
+        loop {
+            let len = match self.reader.read(&mut buf) {
+                Ok(0) => return Ok(()),
+                Ok(len) => len,
+                Err(ref e) if e.kind() == ErrorKind::Interrupted => {
+                    yield_now().await;
+                    continue;
+                }
+                Err(e) => return Err(e),
+            };
+
+            self.writer.write_all(&buf[..len]).await?;
+        }
+    }
+}

--- a/src/body/sync.rs
+++ b/src/body/sync.rs
@@ -2,6 +2,7 @@ use futures_lite::{future::yield_now, io::AsyncWriteExt};
 use sluice::pipe::{pipe, PipeWriter};
 use std::{
     borrow::Cow,
+    fmt,
     fs::File,
     io::{Cursor, ErrorKind, Read, Result},
 };
@@ -88,6 +89,12 @@ impl Read for Body {
     }
 }
 
+impl From<()> for Body {
+    fn from(_: ()) -> Self {
+        Self::from("")
+    }
+}
+
 impl From<Vec<u8>> for Body {
     fn from(body: Vec<u8>) -> Self {
         Self(Repr::Buffer(Cursor::new(Cow::Owned(body))))
@@ -118,6 +125,15 @@ impl From<File> for Body {
             Self::from_reader_sized(file, metadata.len())
         } else {
             Self::from_reader(file)
+        }
+    }
+}
+
+impl fmt::Debug for Body {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self.len() {
+            Some(len) => write!(f, "Body({})", len),
+            None => write!(f, "Body(?)"),
         }
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1201,6 +1201,7 @@ impl fmt::Debug for HttpClient {
 }
 
 /// A future for a request being executed.
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct ResponseFuture<'c>(
     Pin<Box<dyn Future<Output = <Self as Future>::Output> + 'c + Send>>,
 );

--- a/src/cookies/interceptor.rs
+++ b/src/cookies/interceptor.rs
@@ -3,10 +3,10 @@
 
 use super::{Cookie, CookieJar};
 use crate::{
+    body::AsyncBody,
+    error::Error,
     interceptor::{Context, Interceptor, InterceptorFuture},
     response::ResponseExt,
-    Body,
-    Error,
 };
 use http::Request;
 use std::convert::TryInto;
@@ -28,7 +28,7 @@ impl CookieInterceptor {
 impl Interceptor for CookieInterceptor {
     type Err = Error;
 
-    fn intercept<'a>(&'a self, mut request: Request<Body>, ctx: Context<'a>) -> InterceptorFuture<'a, Self::Err> {
+    fn intercept<'a>(&'a self, mut request: Request<AsyncBody>, ctx: Context<'a>) -> InterceptorFuture<'a, Self::Err> {
         Box::pin(async move {
             // Determine the cookie jar to use for this request. If one is
             // attached to this specific request, use it, otherwise use the

--- a/src/default_headers.rs
+++ b/src/default_headers.rs
@@ -1,6 +1,7 @@
 use crate::{
+    body::AsyncBody,
+    error::Error,
     interceptor::{Context, Interceptor, InterceptorFuture},
-    Body, Error,
 };
 use http::{HeaderMap, HeaderValue, Request};
 
@@ -21,7 +22,7 @@ impl Interceptor for DefaultHeadersInterceptor {
 
     fn intercept<'a>(
         &'a self,
-        mut request: Request<Body>,
+        mut request: Request<AsyncBody>,
         ctx: Context<'a>,
     ) -> InterceptorFuture<'a, Self::Err> {
         Box::pin(async move {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,7 +3,7 @@
 use crate::{
     body::AsyncBody,
     error::{Error, ErrorKind},
-    headers,
+    parsing::{parse_header, parse_status_line},
     metrics::Metrics,
     response::{LocalAddr, RemoteAddr},
 };
@@ -389,7 +389,7 @@ impl curl::easy::Handler for RequestHandler {
         // HTTP/1.1 connection ourselves.
 
         // Is this the status line?
-        if let Some((version, status)) = headers::parse_status_line(data) {
+        if let Some((version, status)) = parse_status_line(data) {
             self.response_version = Some(version);
             self.response_status_code = Some(status);
 
@@ -401,7 +401,7 @@ impl curl::easy::Handler for RequestHandler {
         }
 
         // Is this a header line?
-        if let Some((name, value)) = headers::parse_header(data) {
+        if let Some((name, value)) = parse_header(data) {
             self.response_headers.append(name, value);
             return true;
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,9 +1,11 @@
 #![allow(unsafe_code)]
 
 use crate::{
+    body::AsyncBody,
+    error::Error,
     headers,
+    metrics::Metrics,
     response::{LocalAddr, RemoteAddr},
-    Body, Error, Metrics,
 };
 use crossbeam_utils::atomic::AtomicCell;
 use curl::easy::{InfoType, ReadError, SeekResult, WriteError};
@@ -28,7 +30,7 @@ use std::{
     task::{Context, Poll, Waker},
 };
 
-pub(crate) struct RequestBody(pub(crate) Body);
+pub(crate) struct RequestBody(pub(crate) AsyncBody);
 
 /// Manages the state of a single request/response life cycle.
 ///
@@ -61,7 +63,7 @@ pub(crate) struct RequestHandler {
     sender: Option<Sender<Result<http::response::Builder, Error>>>,
 
     /// The body to be sent in the request.
-    request_body: Body,
+    request_body: AsyncBody,
 
     /// A waker used with reading the request body asynchronously. Populated by
     /// an agent when the request is initialized.
@@ -116,7 +118,7 @@ struct Shared {
 impl RequestHandler {
     /// Create a new request handler and an associated response future.
     pub(crate) fn new(
-        request_body: Body,
+        request_body: AsyncBody,
     ) -> (
         Self,
         impl Future<Output = Result<Response<ResponseBodyReader>, Error>>,

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -1,191 +1,43 @@
-use http::header::{HeaderName, HeaderValue};
-use http::{StatusCode, Version};
+use http::header::HeaderMap;
 
-pub(crate) fn parse_status_line(line: &[u8]) -> Option<(Version, StatusCode)> {
-    let mut parts = line.split(u8::is_ascii_whitespace);
+/// Extension trait for HTTP requests and responses for accessing common headers
+/// in a typed way.
+///
+/// Eventually this trait can be made public once the types are cleaned up a
+/// bit.
+pub(crate) trait HasHeaders {
+    fn headers(&self) -> &HeaderMap;
 
-    let version = match parts.next()? {
-        b"HTTP/3" => Version::HTTP_3,
-        b"HTTP/2" => Version::HTTP_2,
-        b"HTTP/1.1" => Version::HTTP_11,
-        b"HTTP/1.0" => Version::HTTP_10,
-        b"HTTP/0.9" => Version::HTTP_09,
-        _ => return None,
-    };
+    fn content_length(&self) -> Option<u64> {
+        self
+            .headers()
+            .get(http::header::CONTENT_LENGTH)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.parse().ok())
+    }
 
-    let status_code = parts
-        .find(|s| !s.is_empty())
-        .map(StatusCode::from_bytes)?
-        .ok()?;
-
-    Some((version, status_code))
+    fn content_type(&self) -> Option<&str> {
+        self
+            .headers()
+            .get(http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+    }
 }
 
-pub(crate) fn parse_header(line: &[u8]) -> Option<(HeaderName, HeaderValue)> {
-    let split_index = line.iter().position(|&f| f == b':')?;
-
-    let name = HeaderName::from_bytes(&line[..split_index]).ok()?;
-    let mut value = &line[split_index + 1..];
-
-    // Trim whitespace
-    while let Some((byte, right)) = value.split_first() {
-        if byte.is_ascii_whitespace() {
-            value = right;
-        } else {
-            break;
-        }
+impl HasHeaders for HeaderMap {
+    fn headers(&self) -> &HeaderMap {
+        self
     }
-
-    while let Some((byte, left)) = value.split_last() {
-        if byte.is_ascii_whitespace() {
-            value = left;
-        } else {
-            break;
-        }
-    }
-
-    let value = HeaderValue::from_bytes(value).ok()?;
-
-    Some((name, value))
 }
 
-pub(crate) fn to_curl_string(
-    name: &HeaderName,
-    value: &HeaderValue,
-    title_case: bool,
-) -> String {
-    let header_value = value.to_str().expect("request header value is not valid UTF-8!");
-
-    let mut string = String::new();
-
-    if title_case {
-        let name_bytes: &[u8] = name.as_ref();
-        let mut at_start_of_word = true;
-
-        for &byte in name_bytes {
-            if at_start_of_word {
-                string.push(byte.to_ascii_uppercase().into());
-            } else {
-                string.push(byte.into());
-            }
-
-            at_start_of_word = !byte.is_ascii_alphanumeric();
-        }
-    } else {
-        string.push_str(name.as_str());
+impl<T> HasHeaders for http::Request<T> {
+    fn headers(&self) -> &HeaderMap {
+        self.headers()
     }
-
-    // libcurl requires a special syntax to set a header with an explicit empty
-    // value. See https://curl.haxx.se/libcurl/c/CURLOPT_HTTPHEADER.html.
-    if header_value.trim().is_empty() {
-        string.push(';');
-    } else {
-        string.push(':');
-        string.push_str(header_value);
-    }
-
-    string
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn parse_valid_status_line() {
-        assert_eq!(
-            parse_status_line(b"HTTP/0.9  200  \r\n"),
-            Some((Version::HTTP_09, StatusCode::OK,))
-        );
-        assert_eq!(
-            parse_status_line(b"HTTP/1.0 500 Internal Server Error\r\n"),
-            Some((Version::HTTP_10, StatusCode::INTERNAL_SERVER_ERROR,))
-        );
-        assert_eq!(
-            parse_status_line(b"HTTP/1.1 404 not found \r\n"),
-            Some((Version::HTTP_11, StatusCode::NOT_FOUND,))
-        );
-        assert_eq!(
-            parse_status_line(b"HTTP/2 200\r\n"),
-            Some((Version::HTTP_2, StatusCode::OK,))
-        );
-        assert_eq!(
-            parse_status_line(b"HTTP/3 200\r\n"),
-            Some((Version::HTTP_3, StatusCode::OK,))
-        );
-    }
-
-    #[test]
-    fn parse_invalid_status_line() {
-        assert_eq!(parse_status_line(b""), None);
-        assert_eq!(parse_status_line(b" \r\n"), None);
-        assert_eq!(parse_status_line(b"HTP/foo bar baz\r\n"), None);
-        assert_eq!(parse_status_line(b"a-header: bar\r\n"), None);
-        assert_eq!(
-            parse_status_line(b" HTTP/1.1 500 Internal Server Error\r\n"),
-            None
-        );
-        assert_eq!(parse_status_line(b"HTTP/4 200\r\n"), None);
-    }
-
-    #[test]
-    fn parse_valid_headers() {
-        assert_eq!(
-            parse_header(b"Empty:"),
-            Some(("empty".parse().unwrap(), "".parse().unwrap(),))
-        );
-        assert_eq!(
-            parse_header(b"CONTENT-LENGTH:20\r\n"),
-            Some(("content-length".parse().unwrap(), "20".parse().unwrap(),))
-        );
-        assert_eq!(
-            parse_header(b"x-Server:     Rust \r"),
-            Some(("x-server".parse().unwrap(), "Rust".parse().unwrap(),))
-        );
-        assert_eq!(
-            parse_header(b"X-val: Hello World\r"),
-            Some(("x-val".parse().unwrap(), "Hello World".parse().unwrap(),))
-        );
-
-        assert_eq!(
-            parse_header(b"Location: https://example.com/\r"),
-            Some((
-                "location".parse().unwrap(),
-                "https://example.com/".parse().unwrap(),
-            ))
-        );
-    }
-
-    #[test]
-    fn parse_invalid_headers() {
-        assert_eq!(parse_header(b""), None);
-        assert_eq!(parse_header(b":"), None);
-        assert_eq!(parse_header(b": bar"), None);
-        assert_eq!(parse_header(b"a\nheader: bar"), None);
-        assert_eq!(parse_header(b"foo : bar\r"), None);
-    }
-
-    #[test]
-    fn normal_header_to_curl_string() {
-        let name = "User-Agent".parse().unwrap();
-        let value = "foo".parse().unwrap();
-
-        assert_eq!(to_curl_string(&name, &value, false), "user-agent:foo");
-    }
-
-    #[test]
-    fn blank_header_to_curl_string() {
-        let name = "User-Agent".parse().unwrap();
-        let value = "".parse().unwrap();
-
-        assert_eq!(to_curl_string(&name, &value, false), "user-agent;");
-    }
-
-    #[test]
-    fn normal_header_to_curl_string_title_case() {
-        let name = "User-Agent".parse().unwrap();
-        let value = "foo".parse().unwrap();
-
-        assert_eq!(to_curl_string(&name, &value, true), "User-Agent:foo");
+impl<T> HasHeaders for http::Response<T> {
+    fn headers(&self) -> &HeaderMap {
+        self.headers()
     }
 }

--- a/src/interceptor/context.rs
+++ b/src/interceptor/context.rs
@@ -1,4 +1,4 @@
-use crate::{Body, Error};
+use crate::{body::AsyncBody, error::Error};
 use super::{Interceptor, InterceptorFuture, InterceptorObj};
 use http::{Request, Response};
 use std::{
@@ -15,7 +15,7 @@ pub struct Context<'a> {
 impl<'a> Context<'a> {
     /// Send a request asynchronously, executing the next interceptor in the
     /// chain, if any.
-    pub async fn send(&self, request: Request<Body>) -> Result<Response<Body>, Error> {
+    pub async fn send(&self, request: Request<AsyncBody>) -> Result<Response<AsyncBody>, Error> {
         if let Some(interceptor) = self.interceptors.first() {
             let inner_context = Self {
                 invoker: self.invoker.clone(),
@@ -36,5 +36,5 @@ impl fmt::Debug for Context<'_> {
 }
 
 pub(crate) trait Invoke {
-    fn invoke<'a>(&'a self, request: Request<Body>) -> InterceptorFuture<'a, Error>;
+    fn invoke<'a>(&'a self, request: Request<AsyncBody>) -> InterceptorFuture<'a, Error>;
 }

--- a/src/interceptor/obj.rs
+++ b/src/interceptor/obj.rs
@@ -1,4 +1,4 @@
-use crate::{Body, Error};
+use crate::{body::AsyncBody, error::Error};
 use super::{Context, Interceptor, InterceptorFuture};
 use http::Request;
 
@@ -14,7 +14,7 @@ impl InterceptorObj {
 impl Interceptor for InterceptorObj {
     type Err = Error;
 
-    fn intercept<'a>(&'a self, request: Request<Body>, cx: Context<'a>) -> InterceptorFuture<'a, Self::Err> {
+    fn intercept<'a>(&'a self, request: Request<AsyncBody>, cx: Context<'a>) -> InterceptorFuture<'a, Self::Err> {
         self.0.dyn_intercept(request, cx)
     }
 }
@@ -22,11 +22,11 @@ impl Interceptor for InterceptorObj {
 /// Object-safe version of the interceptor used for type erasure. Implementation
 /// detail of [`InterceptorObj`].
 trait DynInterceptor: Send + Sync {
-    fn dyn_intercept<'a>(&'a self, request: Request<Body>, cx: Context<'a>) -> InterceptorFuture<'a, Error>;
+    fn dyn_intercept<'a>(&'a self, request: Request<AsyncBody>, cx: Context<'a>) -> InterceptorFuture<'a, Error>;
 }
 
 impl<I: Interceptor> DynInterceptor for I {
-    fn dyn_intercept<'a>(&'a self, request: Request<Body>, cx: Context<'a>) -> InterceptorFuture<'a, Error> {
+    fn dyn_intercept<'a>(&'a self, request: Request<AsyncBody>, cx: Context<'a>) -> InterceptorFuture<'a, Error> {
         Box::pin(async move {
             self.intercept(request, cx).await.map_err(Error::from_any)
         })

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ pub use crate::{
     error::Error,
     metrics::Metrics,
     request::RequestExt,
-    response::{AsyncResponseExt, ResponseExt},
+    response::{AsyncReadableResponse, ReadableResponse, ResponseExt},
 };
 
 /// Re-export of the standard HTTP types.
@@ -275,7 +275,8 @@ pub use http;
 pub mod prelude {
     #[doc(no_inline)]
     pub use crate::{
-        AsyncResponseExt,
+        AsyncReadableResponse,
+        ReadableResponse,
         config::Configurable,
         HttpClient,
         RequestExt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -89,8 +89,15 @@
 //! make common tasks convenient and allow you to configure more advanced
 //! connection and protocol details.
 //!
-//! Some key traits to read about include
-//! [`Configurable`](config::Configurable), [`RequestExt`], and [`ResponseExt`].
+//! Here are some of the key traits to read about:
+//!
+//! - [`Configurable`](config::Configurable): Configure request parameters.
+//! - [`RequestExt`]: Manipulate and send requests.
+//! - [`ResponseExt`]: Get information about the corresponding request or
+//!   response statistics.
+//! - [`ReadResponseExt`]: Consume a response body in a variety of ways.
+//! - [`AsyncReadResponseExt`]: Consume an asynchronous response body in a
+//!   variety of ways.
 //!
 //! ## Custom clients
 //!
@@ -118,9 +125,14 @@
 //! use isahc::prelude::*;
 //!
 //! let mut response = isahc::get_async("https://httpbin.org/get").await?;
-//! println!("{}", response.text_async().await?);
+//! println!("{}", response.text().await?);
 //! # Ok(()) }
 //! ```
+//!
+//! Since we sent our request using [`get_async`], no blocking will occur, and
+//! the asynchronous versions of all response methods (such as
+//! [`text`](AsyncReadResponseExt::text)) will also automatically be selected by
+//! the compiler.
 //!
 //! # Feature flags
 //!
@@ -237,6 +249,7 @@ mod default_headers;
 mod handler;
 mod headers;
 mod metrics;
+mod parsing;
 mod redirect;
 mod request;
 mod response;
@@ -259,7 +272,7 @@ pub use crate::{
     error::Error,
     metrics::Metrics,
     request::RequestExt,
-    response::{AsyncReadableResponse, ReadableResponse, ResponseExt},
+    response::{AsyncReadResponseExt, ReadResponseExt, ResponseExt},
 };
 
 /// Re-export of the standard HTTP types.
@@ -275,8 +288,8 @@ pub use http;
 pub mod prelude {
     #[doc(no_inline)]
     pub use crate::{
-        AsyncReadableResponse,
-        ReadableResponse,
+        AsyncReadResponseExt,
+        ReadResponseExt,
         config::Configurable,
         HttpClient,
         RequestExt,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -284,7 +284,7 @@ pub mod prelude {
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::get`] for details.
-pub fn get<U>(uri: U) -> Result<Response<Body>, Error>
+pub fn get<U>(uri: U) -> Result<Response<crate::body::sync::Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
@@ -308,7 +308,7 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::head`] for details.
-pub fn head<U>(uri: U) -> Result<Response<Body>, Error>
+pub fn head<U>(uri: U) -> Result<Response<crate::body::sync::Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
@@ -332,10 +332,11 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::post`] for details.
-pub fn post<U>(uri: U, body: impl Into<Body>) -> Result<Response<Body>, Error>
+pub fn post<U, B>(uri: U, body: B) -> Result<Response<crate::body::sync::Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
+    B: Into<crate::body::sync::Body>,
 {
     HttpClient::shared().post(uri, body)
 }
@@ -345,10 +346,11 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::post_async`] for details.
-pub fn post_async<U>(uri: U, body: impl Into<Body>) -> ResponseFuture<'static>
+pub fn post_async<U, B>(uri: U, body: B) -> ResponseFuture<'static>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
+    B: Into<Body>,
 {
     HttpClient::shared().post_async(uri, body)
 }
@@ -357,10 +359,11 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::put`] for details.
-pub fn put<U>(uri: U, body: impl Into<Body>) -> Result<Response<Body>, Error>
+pub fn put<U, B>(uri: U, body: B) -> Result<Response<crate::body::sync::Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
+    B: Into<crate::body::sync::Body>,
 {
     HttpClient::shared().put(uri, body)
 }
@@ -370,10 +373,11 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::put_async`] for details.
-pub fn put_async<U>(uri: U, body: impl Into<Body>) -> ResponseFuture<'static>
+pub fn put_async<U, B>(uri: U, body: B) -> ResponseFuture<'static>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
+    B: Into<Body>
 {
     HttpClient::shared().put_async(uri, body)
 }
@@ -382,7 +386,7 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::delete`] for details.
-pub fn delete<U>(uri: U) -> Result<Response<Body>, Error>
+pub fn delete<U>(uri: U) -> Result<Response<crate::body::sync::Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
@@ -406,7 +410,7 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::send`] for details.
-pub fn send<B: Into<Body>>(request: Request<B>) -> Result<Response<Body>, Error> {
+pub fn send<B: Into<crate::body::sync::Body>>(request: Request<B>) -> Result<Response<crate::body::sync::Body>, Error> {
     HttpClient::shared().send(request)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -254,7 +254,7 @@ pub mod interceptor;
 pub(crate) mod interceptor;
 
 pub use crate::{
-    body::Body,
+    body::{AsyncBody, Body},
     client::{HttpClient, HttpClientBuilder, ResponseFuture},
     error::Error,
     metrics::Metrics,
@@ -284,7 +284,7 @@ pub mod prelude {
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::get`] for details.
-pub fn get<U>(uri: U) -> Result<Response<crate::body::sync::Body>, Error>
+pub fn get<U>(uri: U) -> Result<Response<Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
@@ -308,7 +308,7 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::head`] for details.
-pub fn head<U>(uri: U) -> Result<Response<crate::body::sync::Body>, Error>
+pub fn head<U>(uri: U) -> Result<Response<Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
@@ -332,11 +332,11 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::post`] for details.
-pub fn post<U, B>(uri: U, body: B) -> Result<Response<crate::body::sync::Body>, Error>
+pub fn post<U, B>(uri: U, body: B) -> Result<Response<Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
-    B: Into<crate::body::sync::Body>,
+    B: Into<Body>,
 {
     HttpClient::shared().post(uri, body)
 }
@@ -350,7 +350,7 @@ pub fn post_async<U, B>(uri: U, body: B) -> ResponseFuture<'static>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
-    B: Into<Body>,
+    B: Into<AsyncBody>,
 {
     HttpClient::shared().post_async(uri, body)
 }
@@ -359,11 +359,11 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::put`] for details.
-pub fn put<U, B>(uri: U, body: B) -> Result<Response<crate::body::sync::Body>, Error>
+pub fn put<U, B>(uri: U, body: B) -> Result<Response<Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
-    B: Into<crate::body::sync::Body>,
+    B: Into<Body>,
 {
     HttpClient::shared().put(uri, body)
 }
@@ -377,7 +377,7 @@ pub fn put_async<U, B>(uri: U, body: B) -> ResponseFuture<'static>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
-    B: Into<Body>
+    B: Into<AsyncBody>
 {
     HttpClient::shared().put_async(uri, body)
 }
@@ -386,7 +386,7 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::delete`] for details.
-pub fn delete<U>(uri: U) -> Result<Response<crate::body::sync::Body>, Error>
+pub fn delete<U>(uri: U) -> Result<Response<Body>, Error>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
@@ -410,7 +410,7 @@ where
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::send`] for details.
-pub fn send<B: Into<crate::body::sync::Body>>(request: Request<B>) -> Result<Response<crate::body::sync::Body>, Error> {
+pub fn send<B: Into<Body>>(request: Request<B>) -> Result<Response<Body>, Error> {
     HttpClient::shared().send(request)
 }
 
@@ -418,7 +418,7 @@ pub fn send<B: Into<crate::body::sync::Body>>(request: Request<B>) -> Result<Res
 ///
 /// The request is executed using a shared [`HttpClient`] instance. See
 /// [`HttpClient::send_async`] for details.
-pub fn send_async<B: Into<Body>>(request: Request<B>) -> ResponseFuture<'static> {
+pub fn send_async<B: Into<AsyncBody>>(request: Request<B>) -> ResponseFuture<'static> {
     HttpClient::shared().send_async(request)
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -259,7 +259,7 @@ pub use crate::{
     error::Error,
     metrics::Metrics,
     request::RequestExt,
-    response::ResponseExt,
+    response::{AsyncResponseExt, ResponseExt},
 };
 
 /// Re-export of the standard HTTP types.
@@ -274,7 +274,13 @@ pub use http;
 /// ```
 pub mod prelude {
     #[doc(no_inline)]
-    pub use crate::{config::Configurable, Body, HttpClient, RequestExt, ResponseExt};
+    pub use crate::{
+        AsyncResponseExt,
+        config::Configurable,
+        HttpClient,
+        RequestExt,
+        ResponseExt,
+    };
 
     #[doc(no_inline)]
     pub use http::{Request, Response};

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,0 +1,191 @@
+use http::header::{HeaderName, HeaderValue};
+use http::{StatusCode, Version};
+
+pub(crate) fn parse_status_line(line: &[u8]) -> Option<(Version, StatusCode)> {
+    let mut parts = line.split(u8::is_ascii_whitespace);
+
+    let version = match parts.next()? {
+        b"HTTP/3" => Version::HTTP_3,
+        b"HTTP/2" => Version::HTTP_2,
+        b"HTTP/1.1" => Version::HTTP_11,
+        b"HTTP/1.0" => Version::HTTP_10,
+        b"HTTP/0.9" => Version::HTTP_09,
+        _ => return None,
+    };
+
+    let status_code = parts
+        .find(|s| !s.is_empty())
+        .map(StatusCode::from_bytes)?
+        .ok()?;
+
+    Some((version, status_code))
+}
+
+pub(crate) fn parse_header(line: &[u8]) -> Option<(HeaderName, HeaderValue)> {
+    let split_index = line.iter().position(|&f| f == b':')?;
+
+    let name = HeaderName::from_bytes(&line[..split_index]).ok()?;
+    let mut value = &line[split_index + 1..];
+
+    // Trim whitespace
+    while let Some((byte, right)) = value.split_first() {
+        if byte.is_ascii_whitespace() {
+            value = right;
+        } else {
+            break;
+        }
+    }
+
+    while let Some((byte, left)) = value.split_last() {
+        if byte.is_ascii_whitespace() {
+            value = left;
+        } else {
+            break;
+        }
+    }
+
+    let value = HeaderValue::from_bytes(value).ok()?;
+
+    Some((name, value))
+}
+
+pub(crate) fn header_to_curl_string(
+    name: &HeaderName,
+    value: &HeaderValue,
+    title_case: bool,
+) -> String {
+    let header_value = value.to_str().expect("request header value is not valid UTF-8!");
+
+    let mut string = String::new();
+
+    if title_case {
+        let name_bytes: &[u8] = name.as_ref();
+        let mut at_start_of_word = true;
+
+        for &byte in name_bytes {
+            if at_start_of_word {
+                string.push(byte.to_ascii_uppercase().into());
+            } else {
+                string.push(byte.into());
+            }
+
+            at_start_of_word = !byte.is_ascii_alphanumeric();
+        }
+    } else {
+        string.push_str(name.as_str());
+    }
+
+    // libcurl requires a special syntax to set a header with an explicit empty
+    // value. See https://curl.haxx.se/libcurl/c/CURLOPT_HTTPHEADER.html.
+    if header_value.trim().is_empty() {
+        string.push(';');
+    } else {
+        string.push(':');
+        string.push_str(header_value);
+    }
+
+    string
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_valid_status_line() {
+        assert_eq!(
+            parse_status_line(b"HTTP/0.9  200  \r\n"),
+            Some((Version::HTTP_09, StatusCode::OK,))
+        );
+        assert_eq!(
+            parse_status_line(b"HTTP/1.0 500 Internal Server Error\r\n"),
+            Some((Version::HTTP_10, StatusCode::INTERNAL_SERVER_ERROR,))
+        );
+        assert_eq!(
+            parse_status_line(b"HTTP/1.1 404 not found \r\n"),
+            Some((Version::HTTP_11, StatusCode::NOT_FOUND,))
+        );
+        assert_eq!(
+            parse_status_line(b"HTTP/2 200\r\n"),
+            Some((Version::HTTP_2, StatusCode::OK,))
+        );
+        assert_eq!(
+            parse_status_line(b"HTTP/3 200\r\n"),
+            Some((Version::HTTP_3, StatusCode::OK,))
+        );
+    }
+
+    #[test]
+    fn parse_invalid_status_line() {
+        assert_eq!(parse_status_line(b""), None);
+        assert_eq!(parse_status_line(b" \r\n"), None);
+        assert_eq!(parse_status_line(b"HTP/foo bar baz\r\n"), None);
+        assert_eq!(parse_status_line(b"a-header: bar\r\n"), None);
+        assert_eq!(
+            parse_status_line(b" HTTP/1.1 500 Internal Server Error\r\n"),
+            None
+        );
+        assert_eq!(parse_status_line(b"HTTP/4 200\r\n"), None);
+    }
+
+    #[test]
+    fn parse_valid_headers() {
+        assert_eq!(
+            parse_header(b"Empty:"),
+            Some(("empty".parse().unwrap(), "".parse().unwrap(),))
+        );
+        assert_eq!(
+            parse_header(b"CONTENT-LENGTH:20\r\n"),
+            Some(("content-length".parse().unwrap(), "20".parse().unwrap(),))
+        );
+        assert_eq!(
+            parse_header(b"x-Server:     Rust \r"),
+            Some(("x-server".parse().unwrap(), "Rust".parse().unwrap(),))
+        );
+        assert_eq!(
+            parse_header(b"X-val: Hello World\r"),
+            Some(("x-val".parse().unwrap(), "Hello World".parse().unwrap(),))
+        );
+
+        assert_eq!(
+            parse_header(b"Location: https://example.com/\r"),
+            Some((
+                "location".parse().unwrap(),
+                "https://example.com/".parse().unwrap(),
+            ))
+        );
+    }
+
+    #[test]
+    fn parse_invalid_headers() {
+        assert_eq!(parse_header(b""), None);
+        assert_eq!(parse_header(b":"), None);
+        assert_eq!(parse_header(b": bar"), None);
+        assert_eq!(parse_header(b"a\nheader: bar"), None);
+        assert_eq!(parse_header(b"foo : bar\r"), None);
+    }
+
+    #[test]
+    fn normal_header_to_curl_string() {
+        let name = "User-Agent".parse().unwrap();
+        let value = "foo".parse().unwrap();
+
+        assert_eq!(header_to_curl_string(&name, &value, false), "user-agent:foo");
+    }
+
+    #[test]
+    fn blank_header_to_curl_string() {
+        let name = "User-Agent".parse().unwrap();
+        let value = "".parse().unwrap();
+
+        assert_eq!(header_to_curl_string(&name, &value, false), "user-agent;");
+    }
+
+    #[test]
+    fn normal_header_to_curl_string_title_case() {
+        let name = "User-Agent".parse().unwrap();
+        let value = "foo".parse().unwrap();
+
+        assert_eq!(header_to_curl_string(&name, &value, true), "User-Agent:foo");
+    }
+}

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -1,10 +1,10 @@
 use crate::{
+    body::AsyncBody,
     config::RedirectPolicy,
     error::{Error, ErrorKind},
     handler::RequestBody,
     interceptor::{Context, Interceptor, InterceptorFuture},
     request::RequestExt,
-    Body,
 };
 use http::{Request, Response, Uri};
 use std::convert::TryFrom;
@@ -27,7 +27,7 @@ impl Interceptor for RedirectInterceptor {
 
     fn intercept<'a>(
         &'a self,
-        mut request: Request<Body>,
+        mut request: Request<AsyncBody>,
         ctx: Context<'a>,
     ) -> InterceptorFuture<'a, Self::Err> {
         Box::pin(async move {

--- a/src/request.rs
+++ b/src/request.rs
@@ -32,9 +32,9 @@ pub trait RequestExt<T> {
     ///     .send()?;
     /// # Ok::<(), isahc::Error>(())
     /// ```
-    fn send(self) -> Result<Response<Body>, Error>
+    fn send(self) -> Result<Response<crate::body::sync::Body>, Error>
     where
-        T: Into<Body>;
+        T: Into<crate::body::sync::Body>;
 
     /// Sends the HTTP request asynchronously using the default client.
     ///
@@ -105,9 +105,9 @@ impl<T> RequestExt<T> for Request<T> {
         builder
     }
 
-    fn send(self) -> Result<Response<Body>, Error>
+    fn send(self) -> Result<Response<crate::body::sync::Body>, Error>
     where
-        T: Into<Body>,
+        T: Into<crate::body::sync::Body>,
     {
         crate::send(self)
     }

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,7 +1,8 @@
 use crate::{
+    body::{AsyncBody, Body},
     client::ResponseFuture,
     config::{internal::ConfigurableBase, Configurable},
-    {Body, Error},
+    error::Error,
 };
 use http::{Request, Response};
 
@@ -32,9 +33,9 @@ pub trait RequestExt<T> {
     ///     .send()?;
     /// # Ok::<(), isahc::Error>(())
     /// ```
-    fn send(self) -> Result<Response<crate::body::sync::Body>, Error>
+    fn send(self) -> Result<Response<Body>, Error>
     where
-        T: Into<crate::body::sync::Body>;
+        T: Into<Body>;
 
     /// Sends the HTTP request asynchronously using the default client.
     ///
@@ -42,7 +43,7 @@ pub trait RequestExt<T> {
     /// [`send_async`](crate::send_async).
     fn send_async(self) -> ResponseFuture<'static>
     where
-        T: Into<Body>;
+        T: Into<AsyncBody>;
 }
 
 impl<T> RequestExt<T> for Request<T> {
@@ -105,16 +106,16 @@ impl<T> RequestExt<T> for Request<T> {
         builder
     }
 
-    fn send(self) -> Result<Response<crate::body::sync::Body>, Error>
+    fn send(self) -> Result<Response<Body>, Error>
     where
-        T: Into<crate::body::sync::Body>,
+        T: Into<Body>,
     {
         crate::send(self)
     }
 
     fn send_async(self) -> ResponseFuture<'static>
     where
-        T: Into<Body>,
+        T: Into<AsyncBody>,
     {
         crate::send_async(self)
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -39,6 +39,7 @@ macro_rules! decode_reader {
 
 /// A future returning a response body decoded as text.
 #[allow(missing_debug_implementations)]
+#[must_use = "futures do nothing unless you `.await` or poll them"]
 pub struct TextFuture<'a, R> {
     inner: Pin<Box<dyn Future<Output = io::Result<String>> + 'a>>,
     _phantom: PhantomData<R>,
@@ -156,7 +157,7 @@ impl Decoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Body;
+    use crate::body::Body;
 
     static_assertions::assert_impl_all!(TextFuture<'_, &mut Body>: Send);
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -2,6 +2,7 @@
 
 #![cfg(feature = "text-decoding")]
 
+use crate::headers::HasHeaders;
 use encoding_rs::{CoderResult, Encoding};
 use futures_lite::io::{AsyncRead, AsyncReadExt};
 use http::Response;
@@ -81,10 +82,7 @@ impl Decoder {
 
     /// Create a new encoder suitable for decoding the given response.
     pub(crate) fn for_response<T>(response: &Response<T>) -> Self {
-        if let Some(content_type) = response
-            .headers()
-            .get(http::header::CONTENT_TYPE)
-            .and_then(|header| header.to_str().ok())
+        if let Some(content_type) = response.content_type()
             .and_then(|header| header.parse::<mime::Mime>().ok())
         {
             if let Some(charset) = content_type.get_param(mime::CHARSET) {

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -1,4 +1,5 @@
 use isahc::{
+    Body,
     config::RedirectPolicy,
     prelude::*,
 };


### PR DESCRIPTION
Make the big split between synchronous responses and asynchronous responses, which offers ergonomic improvements and encourages users towards using the right methods by default as discussed in #202. This required the following changes:

- Split `Body` into two distinct types: `AsyncBody` and `Body`, which are asynchronous only and synchronous only, respectively.
- Split `ResponseExt` into three traits: `ResponseExt` for methods that don't use the body, `ReadResponseExt` for synchronous methods that read from the body, and `AsyncReadResponseExt` for async methods that read from the body. This offers some ergonomic improvements as well, as the async response methods can drop the `_async` suffix, and Rust will automatically resolve to the correct method depending on whether the response is async or not.

This split also enables a new capability that I did not think of before, which is that you can now use anything implementing `Read` as a request body such as `File` when using the synchronous API. For those not using async at all, this is a significant improvement!

Fixes #202.