### PR TITLE
Fix body reporting compressed length with auto decompression

### DIFF
--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -63,6 +63,9 @@ fn request_gzip_without_automatic_decompression() {
 
     assert_eq!(body_received, body_encoded);
     m.request().expect_header("Accept-Encoding", "gzip");
+
+    // Response body size should be known.
+    assert_eq!(response.body().len(), Some(31));
 }
 
 #[test]

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -26,6 +26,10 @@ fn gzip_encoded_response_is_decoded_automatically() {
 
     assert_eq!(response.text().unwrap(), body);
     m.request().expect_header("Accept-Encoding", "deflate, gzip");
+
+    // Response body size should be unknown, because the actual content is
+    // gzipped.
+    assert_eq!(response.body().len(), None);
 }
 
 #[test]
@@ -81,6 +85,10 @@ fn deflate_encoded_response_is_decoded_automatically() {
 
     assert_eq!(response.text().unwrap(), body);
     m.request().expect_header("Accept-Encoding", "deflate, gzip");
+
+    // Response body size should be unknown, because the actual content is
+    // compressed.
+    assert_eq!(response.body().len(), None);
 }
 
 #[test]


### PR DESCRIPTION
When automatic decompression is enabled and a server returns a `Content-Length` response header for compressed content, `Body::len` was naively returning the unmodified value of `Content-Length` as the body length. This is incorrect because the `Content-Length` in this situation indicates the _compressed_ size of the body, not the uncompressed size.

Since `Body::len` is supposed to be reporting the size of the body that it is returning if known, returning the uncompressed size is confusing and buggy, and can (and does) cause issues for downstream users.

This fixes the issue by simply returning `None` as the body length whenever we are decompressing the response body on the user's behalf, since it is impossible for us to know the uncompressed size ahead of time.

Fixes #265.