### PR TITLE
Add rustfmt config and workflow

### DIFF
--- a/.github/workflows/commands.yml
+++ b/.github/workflows/commands.yml
@@ -1,0 +1,35 @@
+name: commands
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  rustfmt:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: xt0rted/slash-command-action@v1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          command: rustfmt
+
+      - id: comment-branch
+        uses: xt0rted/pull-request-comment-branch@v1
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: actions/checkout@v2
+        with:
+          ref: ${{ steps.comment-branch.outputs.head_ref }}
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          default: true
+
+      - run: cargo fmt
+
+      - uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: Apply rustfmt
+          branch: ${{ steps.comment-branch.outputs.head_ref }}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2018"
+imports_layout = "HorizontalVertical"
+merge_imports = true
+overflow_delimited_expr = true
+struct_lit_single_line = false
+use_field_init_shorthand = true
+version = "Two"


### PR DESCRIPTION
Add config for rustfmt as well as a semi-automated workflow for applying it. I'm not a fan of applying it in CI because:

- When used as a condition for CI, a red build is a bit harsh just for formatting issues, when it is trivial to format it without a PR author's involvement.
- Running rustfmt automatically in PRs and pushing if changes were made means that the latest commit doesn't match the PR authors', which less Git-savvy contributors may not know how to deal with. In addition it is just annoying if every other commit is applying another formatting commit.

The idea here is to implement a slash command that can be run manually just prior to merging, if needed.