### PR TITLE
Apply rustfmt to entire repo

### DIFF
--- a/benchmarks/src/lib.rs
+++ b/benchmarks/src/lib.rs
@@ -1,7 +1,5 @@
 use rouille::{Request, Response};
-use std::net::SocketAddr;
-use std::sync::Arc;
-use std::thread;
+use std::{net::SocketAddr, sync::Arc, thread};
 
 pub struct TestServer {
     addr: SocketAddr,
@@ -36,7 +34,7 @@ impl TestServer {
         });
 
         Self {
-            addr: addr,
+            addr,
             counter: Some(counter_outer),
             handle: Some(handle),
         }

--- a/build.rs
+++ b/build.rs
@@ -1,7 +1,4 @@
-use std::env;
-use std::error::Error;
-use std::fs;
-use std::path::PathBuf;
+use std::{env, error::Error, fs, path::PathBuf};
 
 fn main() -> Result<(), Box<dyn Error>> {
     let out_dir = PathBuf::from(env::var("OUT_DIR")?);

--- a/examples/badssl.rs
+++ b/examples/badssl.rs
@@ -1,8 +1,7 @@
 //! This example contains a number of manual tests against badssl.com
 //! demonstrating several dangerous SSL/TLS options.
 
-use isahc::config::SslOption;
-use isahc::prelude::*;
+use isahc::{config::SslOption, prelude::*};
 
 fn main() {
     // accept expired cert

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,10 +1,7 @@
 //! Another simple example that creates a custom HTTP client instance and sends
 //! a GET request with it instead of using the default client.
 
-use isahc::{
-    config::RedirectPolicy,
-    prelude::*,
-};
+use isahc::{config::RedirectPolicy, prelude::*};
 use std::{
     io::{copy, stdout},
     time::Duration,

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -1,8 +1,7 @@
 //! A simple example program that sends a GET request and then prints out all
 //! the cookies in the cookie jar.
 
-use isahc::cookies::CookieJar;
-use isahc::prelude::*;
+use isahc::{cookies::CookieJar, prelude::*};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/examples/http2.rs
+++ b/examples/http2.rs
@@ -1,10 +1,7 @@
 //! This example simply demonstrates HTTP/2 support by making a request that
 //! enforces usage of HTTP/2.
 
-use isahc::{
-    config::VersionNegotiation,
-    prelude::*,
-};
+use isahc::{config::VersionNegotiation, prelude::*};
 
 fn main() -> Result<(), isahc::Error> {
     let response = Request::get("https://nghttp2.org")

--- a/examples/parallel_requests.rs
+++ b/examples/parallel_requests.rs
@@ -8,8 +8,7 @@
 
 use isahc::prelude::*;
 use rayon::prelude::*;
-use std::env;
-use std::time::Instant;
+use std::{env, time::Instant};
 
 fn main() -> Result<(), isahc::Error> {
     let count = env::args()

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,10 +1,8 @@
 //! Types for working with HTTP authentication methods.
 
 use crate::config::{internal::SetOpt, proxy::Proxy};
-use std::{
-    fmt,
-    ops::{BitOr, BitOrAssign},
-};
+use std::fmt;
+use std::ops::{BitOr, BitOrAssign};
 
 /// Credentials consisting of a username and a secret (password) that can be
 /// used to establish user identity.

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -1,8 +1,10 @@
 //! Types for working with HTTP authentication methods.
 
 use crate::config::{internal::SetOpt, proxy::Proxy};
-use std::fmt;
-use std::ops::{BitOr, BitOrAssign};
+use std::{
+    fmt,
+    ops::{BitOr, BitOrAssign},
+};
 
 /// Credentials consisting of a username and a secret (password) that can be
 /// used to establish user identity.

--- a/src/body/sync.rs
+++ b/src/body/sync.rs
@@ -56,7 +56,7 @@ impl Body {
     #[inline]
     pub fn from_bytes_static<B>(bytes: B) -> Self
     where
-        B: AsRef<[u8]> + 'static,
+        B: AsRef<[u8]> + 'static
     {
         match_type! {
             <bytes as Cursor<Cow<'static, [u8]>>> => Self(Inner::Buffer(bytes)),
@@ -166,10 +166,7 @@ impl Body {
                     } else {
                         AsyncBody::from_reader(pipe_reader)
                     },
-                    Some(Writer {
-                        reader,
-                        writer,
-                    }),
+                    Some(Writer { reader, writer }),
                 )
             }
         }

--- a/src/body/sync.rs
+++ b/src/body/sync.rs
@@ -56,7 +56,7 @@ impl Body {
     #[inline]
     pub fn from_bytes_static<B>(bytes: B) -> Self
     where
-        B: AsRef<[u8]> + 'static
+        B: AsRef<[u8]> + 'static,
     {
         match_type! {
             <bytes as Cursor<Cow<'static, [u8]>>> => Self(Inner::Buffer(bytes)),
@@ -166,7 +166,10 @@ impl Body {
                     } else {
                         AsyncBody::from_reader(pipe_reader)
                     },
-                    Some(Writer { reader, writer }),
+                    Some(Writer {
+                        reader,
+                        writer,
+                    }),
                 )
             }
         }

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,10 +4,8 @@ use crate::{
     agent::{self, AgentBuilder},
     auth::{Authentication, Credentials},
     body::{AsyncBody, Body},
-    config::{
-        internal::{ConfigurableBase, SetOpt},
-        *,
-    },
+    config::internal::{ConfigurableBase, SetOpt},
+    config::*,
     default_headers::DefaultHeadersInterceptor,
     error::{Error, ErrorKind},
     handler::{RequestHandler, ResponseBodyReader},
@@ -21,8 +19,7 @@ use futures_lite::{
 };
 use http::{
     header::{HeaderMap, HeaderName, HeaderValue},
-    Request,
-    Response,
+    Request, Response,
 };
 use once_cell::sync::Lazy;
 use std::{
@@ -923,28 +920,27 @@ impl HttpClient {
             async_body
         });
 
-        let response = block_on(
-            async move {
-                // Instead of simply blocking the current thread until the response
-                // is received, we can use the current thread to read from the
-                // request body synchronously while concurrently waiting for the
-                // response.
-                if let Some(mut writer) = writer_maybe {
-                    // Note that the `send_async` future is given first; this
-                    // ensures that it is polled first and thus the request is
-                    // initiated before we attempt to write the request body.
-                    let (response, _) = try_zip(self.send_async_inner(request), async move {
+        let response = block_on(async move {
+            // Instead of simply blocking the current thread until the response
+            // is received, we can use the current thread to read from the
+            // request body synchronously while concurrently waiting for the
+            // response.
+            if let Some(mut writer) = writer_maybe {
+                // Note that the `send_async` future is given first; this
+                // ensures that it is polled first and thus the request is
+                // initiated before we attempt to write the request body.
+                let (response, _) = try_zip(
+                    self.send_async_inner(request),
+                    async move {
                         writer.write().await.map_err(Error::from)
-                    })
-                    .await?;
+                    },
+                ).await?;
 
-                    Ok(response)
-                } else {
-                    self.send_async_inner(request).await
-                }
+                Ok(response)
+            } else {
+                self.send_async_inner(request).await
             }
-            .instrument(span),
-        )?;
+        }.instrument(span))?;
 
         Ok(response.map(|body| body.into_sync()))
     }
@@ -983,17 +979,11 @@ impl HttpClient {
             uri = ?request.uri(),
         );
 
-        ResponseFuture::new(
-            self.send_async_inner(request.map(Into::into))
-                .instrument(span),
-        )
+        ResponseFuture::new(self.send_async_inner(request.map(Into::into)).instrument(span))
     }
 
     /// Actually send the request. All the public methods go through here.
-    async fn send_async_inner(
-        &self,
-        mut request: Request<AsyncBody>,
-    ) -> Result<Response<AsyncBody>, Error> {
+    async fn send_async_inner(&self, mut request: Request<AsyncBody>) -> Result<Response<AsyncBody>, Error> {
         // Set redirect policy if not specified.
         if request.extensions().get::<RedirectPolicy>().is_none() {
             if let Some(policy) = self.inner.defaults.get::<RedirectPolicy>().cloned() {
@@ -1171,9 +1161,7 @@ impl crate::interceptor::Invoke for &HttpClient {
 
             // Check if automatic decompression is enabled; we'll need to know
             // this later after the response is sent.
-            let is_automatic_decompression = request
-                .extensions()
-                .get()
+            let is_automatic_decompression = request.extensions().get()
                 .or_else(|| self.inner.defaults.get())
                 .map(|AutomaticDecompression(enabled)| *enabled)
                 .unwrap_or(false);
@@ -1234,7 +1222,9 @@ impl fmt::Debug for HttpClient {
 
 /// A future for a request being executed.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct ResponseFuture<'c>(Pin<Box<dyn Future<Output = <Self as Future>::Output> + 'c + Send>>);
+pub struct ResponseFuture<'c>(
+    Pin<Box<dyn Future<Output = <Self as Future>::Output> + 'c + Send>>,
+);
 
 impl<'c> ResponseFuture<'c> {
     fn new<F>(future: F) -> Self
@@ -1245,7 +1235,9 @@ impl<'c> ResponseFuture<'c> {
     }
 
     fn error(error: Error) -> Self {
-        Self::new(async move { Err(error) })
+        Self::new(async move {
+            Err(error)
+        })
     }
 }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -4,8 +4,10 @@ use crate::{
     agent::{self, AgentBuilder},
     auth::{Authentication, Credentials},
     body::{AsyncBody, Body},
-    config::internal::{ConfigurableBase, SetOpt},
-    config::*,
+    config::{
+        internal::{ConfigurableBase, SetOpt},
+        *,
+    },
     default_headers::DefaultHeadersInterceptor,
     error::{Error, ErrorKind},
     handler::{RequestHandler, ResponseBodyReader},
@@ -19,7 +21,8 @@ use futures_lite::{
 };
 use http::{
     header::{HeaderMap, HeaderName, HeaderValue},
-    Request, Response,
+    Request,
+    Response,
 };
 use once_cell::sync::Lazy;
 use std::{
@@ -920,27 +923,28 @@ impl HttpClient {
             async_body
         });
 
-        let response = block_on(async move {
-            // Instead of simply blocking the current thread until the response
-            // is received, we can use the current thread to read from the
-            // request body synchronously while concurrently waiting for the
-            // response.
-            if let Some(mut writer) = writer_maybe {
-                // Note that the `send_async` future is given first; this
-                // ensures that it is polled first and thus the request is
-                // initiated before we attempt to write the request body.
-                let (response, _) = try_zip(
-                    self.send_async_inner(request),
-                    async move {
+        let response = block_on(
+            async move {
+                // Instead of simply blocking the current thread until the response
+                // is received, we can use the current thread to read from the
+                // request body synchronously while concurrently waiting for the
+                // response.
+                if let Some(mut writer) = writer_maybe {
+                    // Note that the `send_async` future is given first; this
+                    // ensures that it is polled first and thus the request is
+                    // initiated before we attempt to write the request body.
+                    let (response, _) = try_zip(self.send_async_inner(request), async move {
                         writer.write().await.map_err(Error::from)
-                    },
-                ).await?;
+                    })
+                    .await?;
 
-                Ok(response)
-            } else {
-                self.send_async_inner(request).await
+                    Ok(response)
+                } else {
+                    self.send_async_inner(request).await
+                }
             }
-        }.instrument(span))?;
+            .instrument(span),
+        )?;
 
         Ok(response.map(|body| body.into_sync()))
     }
@@ -979,11 +983,17 @@ impl HttpClient {
             uri = ?request.uri(),
         );
 
-        ResponseFuture::new(self.send_async_inner(request.map(Into::into)).instrument(span))
+        ResponseFuture::new(
+            self.send_async_inner(request.map(Into::into))
+                .instrument(span),
+        )
     }
 
     /// Actually send the request. All the public methods go through here.
-    async fn send_async_inner(&self, mut request: Request<AsyncBody>) -> Result<Response<AsyncBody>, Error> {
+    async fn send_async_inner(
+        &self,
+        mut request: Request<AsyncBody>,
+    ) -> Result<Response<AsyncBody>, Error> {
         // Set redirect policy if not specified.
         if request.extensions().get::<RedirectPolicy>().is_none() {
             if let Some(policy) = self.inner.defaults.get::<RedirectPolicy>().cloned() {
@@ -1161,7 +1171,9 @@ impl crate::interceptor::Invoke for &HttpClient {
 
             // Check if automatic decompression is enabled; we'll need to know
             // this later after the response is sent.
-            let is_automatic_decompression = request.extensions().get()
+            let is_automatic_decompression = request
+                .extensions()
+                .get()
                 .or_else(|| self.inner.defaults.get())
                 .map(|AutomaticDecompression(enabled)| *enabled)
                 .unwrap_or(false);
@@ -1222,9 +1234,7 @@ impl fmt::Debug for HttpClient {
 
 /// A future for a request being executed.
 #[must_use = "futures do nothing unless you `.await` or poll them"]
-pub struct ResponseFuture<'c>(
-    Pin<Box<dyn Future<Output = <Self as Future>::Output> + 'c + Send>>,
-);
+pub struct ResponseFuture<'c>(Pin<Box<dyn Future<Output = <Self as Future>::Output> + 'c + Send>>);
 
 impl<'c> ResponseFuture<'c> {
     fn new<F>(future: F) -> Self
@@ -1235,9 +1245,7 @@ impl<'c> ResponseFuture<'c> {
     }
 
     fn error(error: Error) -> Self {
-        Self::new(async move {
-            Err(error)
-        })
+        Self::new(async move { Err(error) })
     }
 }
 

--- a/src/config/dial.rs
+++ b/src/config/dial.rs
@@ -4,7 +4,12 @@
 use super::SetOpt;
 use curl::easy::{Easy2, List};
 use http::Uri;
-use std::{convert::TryFrom, fmt, net::SocketAddr, str::FromStr};
+use std::{
+    convert::TryFrom,
+    fmt,
+    net::SocketAddr,
+    str::FromStr,
+};
 
 /// An error which can be returned when parsing a dial address.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/config/dial.rs
+++ b/src/config/dial.rs
@@ -4,12 +4,7 @@
 use super::SetOpt;
 use curl::easy::{Easy2, List};
 use http::Uri;
-use std::{
-    convert::TryFrom,
-    fmt,
-    net::SocketAddr,
-    str::FromStr,
-};
+use std::{convert::TryFrom, fmt, net::SocketAddr, str::FromStr};
 
 /// An error which can be returned when parsing a dial address.
 #[derive(Clone, Debug, Eq, PartialEq)]

--- a/src/config/dns.rs
+++ b/src/config/dns.rs
@@ -2,7 +2,10 @@
 
 use super::SetOpt;
 use curl::easy::Easy2;
-use std::{net::IpAddr, time::Duration};
+use std::{
+    net::IpAddr,
+    time::Duration,
+};
 
 /// DNS caching configuration.
 ///

--- a/src/config/dns.rs
+++ b/src/config/dns.rs
@@ -2,10 +2,7 @@
 
 use super::SetOpt;
 use curl::easy::Easy2;
-use std::{
-    net::IpAddr,
-    time::Duration,
-};
+use std::{net::IpAddr, time::Duration};
 
 /// DNS caching configuration.
 ///

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,7 +16,11 @@
 use self::internal::SetOpt;
 use crate::auth::{Authentication, Credentials};
 use curl::easy::Easy2;
-use std::{iter::FromIterator, net::IpAddr, time::Duration};
+use std::{
+    iter::FromIterator,
+    net::IpAddr,
+    time::Duration,
+};
 
 pub(crate) mod dial;
 pub(crate) mod dns;
@@ -690,9 +694,7 @@ impl NetworkInterface {
     /// Bind to whatever the networking stack finds suitable. This is the
     /// default behavior.
     pub fn any() -> Self {
-        Self {
-            interface: None,
-        }
+        Self { interface: None }
     }
 
     /// Bind to the interface with the given name (such as `eth0`). This method

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,11 +16,7 @@
 use self::internal::SetOpt;
 use crate::auth::{Authentication, Credentials};
 use curl::easy::Easy2;
-use std::{
-    iter::FromIterator,
-    net::IpAddr,
-    time::Duration,
-};
+use std::{iter::FromIterator, net::IpAddr, time::Duration};
 
 pub(crate) mod dial;
 pub(crate) mod dns;
@@ -694,7 +690,9 @@ impl NetworkInterface {
     /// Bind to whatever the networking stack finds suitable. This is the
     /// default behavior.
     pub fn any() -> Self {
-        Self { interface: None }
+        Self {
+            interface: None,
+        }
     }
 
     /// Bind to the interface with the given name (such as `eth0`). This method

--- a/src/cookies/cookie.rs
+++ b/src/cookies/cookie.rs
@@ -1,5 +1,9 @@
 use chrono::{prelude::*, Duration};
-use std::{error::Error, fmt, str};
+use std::{
+    error::Error,
+    fmt,
+    str,
+};
 
 /// An error which can occur when attempting to parse a cookie string.
 #[derive(Debug)]
@@ -242,10 +246,12 @@ fn parse_cookie_value(mut bytes: &[u8]) -> Result<&str, ParseError> {
 
 // https://tools.ietf.org/html/rfc6265#section-4.1.1
 fn is_valid_cookie_value(bytes: &[u8]) -> bool {
-    bytes.iter().all(|&byte| match byte {
-        0x21 | 0x23..=0x2B | 0x2D..=0x3A | 0x3C..=0x5B | 0x5D..=0x7E => true,
-        _ => false,
-    })
+    bytes
+        .iter()
+        .all(|&byte| match byte {
+            0x21 | 0x23..=0x2B | 0x2D..=0x3A | 0x3C..=0x5B | 0x5D..=0x7E => true,
+            _ => false,
+        })
 }
 
 // https://tools.ietf.org/html/rfc2616#section-2.2

--- a/src/cookies/cookie.rs
+++ b/src/cookies/cookie.rs
@@ -1,9 +1,5 @@
 use chrono::{prelude::*, Duration};
-use std::{
-    error::Error,
-    fmt,
-    str,
-};
+use std::{error::Error, fmt, str};
 
 /// An error which can occur when attempting to parse a cookie string.
 #[derive(Debug)]
@@ -246,12 +242,10 @@ fn parse_cookie_value(mut bytes: &[u8]) -> Result<&str, ParseError> {
 
 // https://tools.ietf.org/html/rfc6265#section-4.1.1
 fn is_valid_cookie_value(bytes: &[u8]) -> bool {
-    bytes
-        .iter()
-        .all(|&byte| match byte {
-            0x21 | 0x23..=0x2B | 0x2D..=0x3A | 0x3C..=0x5B | 0x5D..=0x7E => true,
-            _ => false,
-        })
+    bytes.iter().all(|&byte| match byte {
+        0x21 | 0x23..=0x2B | 0x2D..=0x3A | 0x3C..=0x5B | 0x5D..=0x7E => true,
+        _ => false,
+    })
 }
 
 // https://tools.ietf.org/html/rfc2616#section-2.2

--- a/src/cookies/interceptor.rs
+++ b/src/cookies/interceptor.rs
@@ -28,25 +28,18 @@ impl CookieInterceptor {
 impl Interceptor for CookieInterceptor {
     type Err = Error;
 
-    fn intercept<'a>(
-        &'a self,
-        mut request: Request<AsyncBody>,
-        ctx: Context<'a>,
-    ) -> InterceptorFuture<'a, Self::Err> {
+    fn intercept<'a>(&'a self, mut request: Request<AsyncBody>, ctx: Context<'a>) -> InterceptorFuture<'a, Self::Err> {
         Box::pin(async move {
             // Determine the cookie jar to use for this request. If one is
             // attached to this specific request, use it, otherwise use the
             // default one.
-            let jar = request
-                .extensions()
-                .get::<CookieJar>()
+            let jar = request.extensions().get::<CookieJar>()
                 .cloned()
                 .or_else(|| self.cookie_jar.clone());
 
             if let Some(jar) = jar.as_ref() {
                 // Get the outgoing cookie header.
-                let mut cookie_string = request
-                    .headers_mut()
+                let mut cookie_string = request.headers_mut()
                     .remove(http::header::COOKIE)
                     .map(|value| value.as_bytes().to_vec())
                     .unwrap_or_default();
@@ -77,7 +70,8 @@ impl Interceptor for CookieInterceptor {
             if let Some(jar) = jar {
                 // Persist cookies returned from the server, if any.
                 if response.headers().contains_key(http::header::SET_COOKIE) {
-                    let request_uri = response.effective_uri().unwrap_or(&request_uri);
+                    let request_uri = response.effective_uri()
+                        .unwrap_or(&request_uri);
 
                     let cookies = response
                         .headers()
@@ -89,12 +83,10 @@ impl Interceptor for CookieInterceptor {
                                 None
                             })
                         })
-                        .filter_map(|header| {
-                            Cookie::parse(header).ok().or_else(|| {
-                                tracing::warn!("could not parse Set-Cookie header");
-                                None
-                            })
-                        });
+                        .filter_map(|header| Cookie::parse(header).ok().or_else(|| {
+                            tracing::warn!("could not parse Set-Cookie header");
+                            None
+                        }));
 
                     for cookie in cookies {
                         jar.set(cookie, request_uri);

--- a/src/cookies/jar.rs
+++ b/src/cookies/jar.rs
@@ -55,7 +55,8 @@ impl CookieJar {
     pub fn get_for_uri(&self, uri: &Uri) -> impl IntoIterator<Item = Cookie> {
         let jar = self.cookies.read().unwrap();
 
-        let mut cookies = jar.iter()
+        let mut cookies = jar
+            .iter()
             .filter(|cookie| cookie.matches(uri))
             .map(|c| c.cookie.clone())
             .collect::<Vec<_>>();

--- a/src/cookies/jar.rs
+++ b/src/cookies/jar.rs
@@ -55,8 +55,7 @@ impl CookieJar {
     pub fn get_for_uri(&self, uri: &Uri) -> impl IntoIterator<Item = Cookie> {
         let jar = self.cookies.read().unwrap();
 
-        let mut cookies = jar
-            .iter()
+        let mut cookies = jar.iter()
             .filter(|cookie| cookie.matches(uri))
             .map(|c| c.cookie.clone())
             .collect::<Vec<_>>();

--- a/src/cookies/mod.rs
+++ b/src/cookies/mod.rs
@@ -25,13 +25,10 @@
 //! feature is enabled.
 
 mod cookie;
-mod jar;
 pub(crate) mod interceptor;
+mod jar;
 
 #[cfg(feature = "psl")]
 mod psl;
 
-pub use self::{
-    cookie::Cookie,
-    jar::CookieJar,
-};
+pub use self::{cookie::Cookie, jar::CookieJar};

--- a/src/cookies/mod.rs
+++ b/src/cookies/mod.rs
@@ -25,10 +25,13 @@
 //! feature is enabled.
 
 mod cookie;
-pub(crate) mod interceptor;
 mod jar;
+pub(crate) mod interceptor;
 
 #[cfg(feature = "psl")]
 mod psl;
 
-pub use self::{cookie::Cookie, jar::CookieJar};
+pub use self::{
+    cookie::Cookie,
+    jar::CookieJar,
+};

--- a/src/cookies/psl/mod.rs
+++ b/src/cookies/psl/mod.rs
@@ -20,7 +20,10 @@
 //! since a stale list is better than no list at all.
 
 use crate::request::RequestExt;
-use chrono::{prelude::*, Duration};
+use chrono::{
+    prelude::*,
+    Duration,
+};
 use once_cell::sync::Lazy;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use publicsuffix::List;

--- a/src/cookies/psl/mod.rs
+++ b/src/cookies/psl/mod.rs
@@ -20,10 +20,7 @@
 //! since a stale list is better than no list at all.
 
 use crate::request::RequestExt;
-use chrono::{
-    prelude::*,
-    Duration,
-};
+use chrono::{prelude::*, Duration};
 use once_cell::sync::Lazy;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use publicsuffix::List;

--- a/src/default_headers.rs
+++ b/src/default_headers.rs
@@ -13,9 +13,7 @@ pub(crate) struct DefaultHeadersInterceptor {
 
 impl From<HeaderMap<HeaderValue>> for DefaultHeadersInterceptor {
     fn from(headers: HeaderMap<HeaderValue>) -> Self {
-        Self {
-            headers,
-        }
+        Self { headers }
     }
 }
 

--- a/src/default_headers.rs
+++ b/src/default_headers.rs
@@ -13,7 +13,9 @@ pub(crate) struct DefaultHeadersInterceptor {
 
 impl From<HeaderMap<HeaderValue>> for DefaultHeadersInterceptor {
     fn from(headers: HeaderMap<HeaderValue>) -> Self {
-        Self { headers }
+        Self {
+            headers,
+        }
     }
 }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,13 +90,23 @@ impl ErrorKind {
             Self::BadServerCertificate => Some("the server certificate could not be validated"),
             Self::ClientInitialization => Some("failed to initialize client"),
             Self::ConnectionFailed => Some("failed to connect to the server"),
-            Self::InvalidContentEncoding => Some("the server either returned a response using an unknown or unsupported encoding format, or the response encoding was malformed"),
-            Self::InvalidCredentials => Some("provided authentication credentials were rejected by the server"),
+            Self::InvalidContentEncoding => Some(
+                "the server either returned a response using an unknown or unsupported encoding format, or the response encoding was malformed",
+            ),
+            Self::InvalidCredentials => {
+                Some("provided authentication credentials were rejected by the server")
+            }
             Self::InvalidRequest => Some("invalid HTTP request"),
             Self::NameResolution => Some("failed to resolve host name"),
-            Self::ProtocolViolation => Some("the server made an unrecoverable HTTP protocol violation"),
-            Self::RequestBodyNotRewindable => Some("request body could not be re-sent because it is not rewindable"),
-            Self::Timeout => Some("request or operation took longer than the configured timeout time"),
+            Self::ProtocolViolation => {
+                Some("the server made an unrecoverable HTTP protocol violation")
+            }
+            Self::RequestBodyNotRewindable => {
+                Some("request body could not be re-sent because it is not rewindable")
+            }
+            Self::Timeout => {
+                Some("request or operation took longer than the configured timeout time")
+            }
             Self::TlsEngine => Some("error ocurred in the secure socket engine"),
             Self::TooManyRedirects => Some("number of redirects hit the maximum amount"),
             _ => None,
@@ -213,9 +223,9 @@ impl Error {
     /// Returns true if this error was likely the fault of the server.
     pub fn is_server(&self) -> bool {
         match self.kind() {
-            ErrorKind::BadServerCertificate | ErrorKind::ProtocolViolation | ErrorKind::TooManyRedirects => {
-                true
-            }
+            ErrorKind::BadServerCertificate
+            | ErrorKind::ProtocolViolation
+            | ErrorKind::TooManyRedirects => true,
             _ => false,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -90,23 +90,13 @@ impl ErrorKind {
             Self::BadServerCertificate => Some("the server certificate could not be validated"),
             Self::ClientInitialization => Some("failed to initialize client"),
             Self::ConnectionFailed => Some("failed to connect to the server"),
-            Self::InvalidContentEncoding => Some(
-                "the server either returned a response using an unknown or unsupported encoding format, or the response encoding was malformed",
-            ),
-            Self::InvalidCredentials => {
-                Some("provided authentication credentials were rejected by the server")
-            }
+            Self::InvalidContentEncoding => Some("the server either returned a response using an unknown or unsupported encoding format, or the response encoding was malformed"),
+            Self::InvalidCredentials => Some("provided authentication credentials were rejected by the server"),
             Self::InvalidRequest => Some("invalid HTTP request"),
             Self::NameResolution => Some("failed to resolve host name"),
-            Self::ProtocolViolation => {
-                Some("the server made an unrecoverable HTTP protocol violation")
-            }
-            Self::RequestBodyNotRewindable => {
-                Some("request body could not be re-sent because it is not rewindable")
-            }
-            Self::Timeout => {
-                Some("request or operation took longer than the configured timeout time")
-            }
+            Self::ProtocolViolation => Some("the server made an unrecoverable HTTP protocol violation"),
+            Self::RequestBodyNotRewindable => Some("request body could not be re-sent because it is not rewindable"),
+            Self::Timeout => Some("request or operation took longer than the configured timeout time"),
             Self::TlsEngine => Some("error ocurred in the secure socket engine"),
             Self::TooManyRedirects => Some("number of redirects hit the maximum amount"),
             _ => None,
@@ -223,9 +213,9 @@ impl Error {
     /// Returns true if this error was likely the fault of the server.
     pub fn is_server(&self) -> bool {
         match self.kind() {
-            ErrorKind::BadServerCertificate
-            | ErrorKind::ProtocolViolation
-            | ErrorKind::TooManyRedirects => true,
+            ErrorKind::BadServerCertificate | ErrorKind::ProtocolViolation | ErrorKind::TooManyRedirects => {
+                true
+            }
             _ => false,
         }
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,8 +3,8 @@
 use crate::{
     body::AsyncBody,
     error::{Error, ErrorKind},
-    parsing::{parse_header, parse_status_line},
     metrics::Metrics,
+    parsing::{parse_header, parse_status_line},
     response::{LocalAddr, RemoteAddr},
 };
 use crossbeam_utils::atomic::AtomicCell;
@@ -148,14 +148,19 @@ impl RequestHandler {
         // Create a future that resolves when the handler receives the response
         // headers.
         let future = async move {
-            let builder = receiver.recv_async().await.map_err(|e| Error::new(ErrorKind::Unknown, e))??;
+            let builder = receiver
+                .recv_async()
+                .await
+                .map_err(|e| Error::new(ErrorKind::Unknown, e))??;
 
             let reader = ResponseBodyReader {
                 inner: response_body_reader,
                 shared,
             };
 
-            builder.body(reader).map_err(|e| Error::new(ErrorKind::ProtocolViolation, e))
+            builder
+                .body(reader)
+                .map_err(|e| Error::new(ErrorKind::ProtocolViolation, e))
         };
 
         (handler, future)
@@ -507,7 +512,9 @@ impl curl::easy::Handler for RequestHandler {
                 Poll::Ready(Ok(len)) => Ok(len),
                 Poll::Ready(Err(e)) => {
                     if e.kind() == io::ErrorKind::BrokenPipe {
-                        tracing::warn!("failed to write response body because the response reader was dropped");
+                        tracing::warn!(
+                            "failed to write response body because the response reader was dropped"
+                        );
                     } else {
                         tracing::error!("error writing response body to buffer: {}", e);
                     }
@@ -660,7 +667,7 @@ impl AsyncRead for ResponseBodyReader {
 
                 // The transfer did not finish properly at all, so return an error.
                 None => Poll::Ready(Err(io::ErrorKind::ConnectionAborted.into())),
-            }
+            },
             poll => poll,
         }
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -3,8 +3,8 @@
 use crate::{
     body::AsyncBody,
     error::{Error, ErrorKind},
-    metrics::Metrics,
     parsing::{parse_header, parse_status_line},
+    metrics::Metrics,
     response::{LocalAddr, RemoteAddr},
 };
 use crossbeam_utils::atomic::AtomicCell;
@@ -148,19 +148,14 @@ impl RequestHandler {
         // Create a future that resolves when the handler receives the response
         // headers.
         let future = async move {
-            let builder = receiver
-                .recv_async()
-                .await
-                .map_err(|e| Error::new(ErrorKind::Unknown, e))??;
+            let builder = receiver.recv_async().await.map_err(|e| Error::new(ErrorKind::Unknown, e))??;
 
             let reader = ResponseBodyReader {
                 inner: response_body_reader,
                 shared,
             };
 
-            builder
-                .body(reader)
-                .map_err(|e| Error::new(ErrorKind::ProtocolViolation, e))
+            builder.body(reader).map_err(|e| Error::new(ErrorKind::ProtocolViolation, e))
         };
 
         (handler, future)
@@ -512,9 +507,7 @@ impl curl::easy::Handler for RequestHandler {
                 Poll::Ready(Ok(len)) => Ok(len),
                 Poll::Ready(Err(e)) => {
                     if e.kind() == io::ErrorKind::BrokenPipe {
-                        tracing::warn!(
-                            "failed to write response body because the response reader was dropped"
-                        );
+                        tracing::warn!("failed to write response body because the response reader was dropped");
                     } else {
                         tracing::error!("error writing response body to buffer: {}", e);
                     }
@@ -667,7 +660,7 @@ impl AsyncRead for ResponseBodyReader {
 
                 // The transfer did not finish properly at all, so return an error.
                 None => Poll::Ready(Err(io::ErrorKind::ConnectionAborted.into())),
-            },
+            }
             poll => poll,
         }
     }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -9,16 +9,14 @@ pub(crate) trait HasHeaders {
     fn headers(&self) -> &HeaderMap;
 
     fn content_length(&self) -> Option<u64> {
-        self
-            .headers()
+        self.headers()
             .get(http::header::CONTENT_LENGTH)
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse().ok())
     }
 
     fn content_type(&self) -> Option<&str> {
-        self
-            .headers()
+        self.headers()
             .get(http::header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
     }

--- a/src/headers.rs
+++ b/src/headers.rs
@@ -9,14 +9,16 @@ pub(crate) trait HasHeaders {
     fn headers(&self) -> &HeaderMap;
 
     fn content_length(&self) -> Option<u64> {
-        self.headers()
+        self
+            .headers()
             .get(http::header::CONTENT_LENGTH)
             .and_then(|v| v.to_str().ok())
             .and_then(|v| v.parse().ok())
     }
 
     fn content_type(&self) -> Option<&str> {
-        self.headers()
+        self
+            .headers()
             .get(http::header::CONTENT_TYPE)
             .and_then(|v| v.to_str().ok())
     }

--- a/src/interceptor/context.rs
+++ b/src/interceptor/context.rs
@@ -1,10 +1,7 @@
-use crate::{body::AsyncBody, error::Error};
 use super::{Interceptor, InterceptorFuture, InterceptorObj};
+use crate::{body::AsyncBody, error::Error};
 use http::{Request, Response};
-use std::{
-    fmt,
-    sync::Arc,
-};
+use std::{fmt, sync::Arc};
 
 /// Execution context for an interceptor.
 pub struct Context<'a> {

--- a/src/interceptor/context.rs
+++ b/src/interceptor/context.rs
@@ -1,7 +1,10 @@
-use super::{Interceptor, InterceptorFuture, InterceptorObj};
 use crate::{body::AsyncBody, error::Error};
+use super::{Interceptor, InterceptorFuture, InterceptorObj};
 use http::{Request, Response};
-use std::{fmt, sync::Arc};
+use std::{
+    fmt,
+    sync::Arc,
+};
 
 /// Execution context for an interceptor.
 pub struct Context<'a> {

--- a/src/interceptor/mod.rs
+++ b/src/interceptor/mod.rs
@@ -26,15 +26,24 @@
 /// This module is only available when the
 /// [`unstable-interceptors`](../index.html#unstable-interceptors) feature is
 /// enabled.
+
 use crate::body::AsyncBody;
 use http::{Request, Response};
-use std::{error::Error, fmt, future::Future, pin::Pin};
+use std::{
+    error::Error,
+    fmt,
+    future::Future,
+    pin::Pin,
+};
 
 mod context;
 mod obj;
 
 pub use self::context::Context;
-pub(crate) use self::{context::Invoke, obj::InterceptorObj};
+pub(crate) use self::{
+    context::Invoke,
+    obj::InterceptorObj,
+};
 
 type InterceptorResult<E> = Result<Response<AsyncBody>, E>;
 
@@ -49,7 +58,9 @@ macro_rules! interceptor {
             mut $request: $crate::http::Request<$crate::AsyncBody>,
             $ctx: $crate::interceptor::Context<'_>,
         ) -> Result<$crate::http::Response<$crate::AsyncBody>, $crate::Error> {
-            (move || async move { $body })().await.map_err(Into::into)
+            (move || async move {
+                $body
+            })().await.map_err(Into::into)
         }
 
         $crate::interceptor::from_fn(interceptor)
@@ -69,11 +80,7 @@ pub trait Interceptor: Send + Sync {
     ///
     /// The returned future is allowed to borrow the interceptor for the
     /// duration of its execution.
-    fn intercept<'a>(
-        &'a self,
-        request: Request<AsyncBody>,
-        ctx: Context<'a>,
-    ) -> InterceptorFuture<'a, Self::Err>;
+    fn intercept<'a>(&'a self, request: Request<AsyncBody>, ctx: Context<'a>) -> InterceptorFuture<'a, Self::Err>;
 }
 
 /// The type of future returned by an interceptor.
@@ -82,10 +89,7 @@ pub type InterceptorFuture<'a, E> = Pin<Box<dyn Future<Output = InterceptorResul
 /// Creates an interceptor from an arbitrary closure or function.
 pub fn from_fn<F, E>(f: F) -> InterceptorFn<F>
 where
-    F: for<'a> private::AsyncFn2<Request<AsyncBody>, Context<'a>, Output = InterceptorResult<E>>
-        + Send
-        + Sync
-        + 'static,
+    F: for<'a> private::AsyncFn2<Request<AsyncBody>, Context<'a>, Output = InterceptorResult<E>> + Send + Sync + 'static,
     E: Error + Send + Sync + 'static,
 {
     InterceptorFn(f)
@@ -98,18 +102,11 @@ pub struct InterceptorFn<F>(F);
 impl<E, F> Interceptor for InterceptorFn<F>
 where
     E: Error + Send + Sync + 'static,
-    F: for<'a> private::AsyncFn2<Request<AsyncBody>, Context<'a>, Output = InterceptorResult<E>>
-        + Send
-        + Sync
-        + 'static,
+    F: for<'a> private::AsyncFn2<Request<AsyncBody>, Context<'a>, Output = InterceptorResult<E>> + Send + Sync + 'static,
 {
     type Err = E;
 
-    fn intercept<'a>(
-        &self,
-        request: Request<AsyncBody>,
-        ctx: Context<'a>,
-    ) -> InterceptorFuture<'a, Self::Err> {
+    fn intercept<'a>(&self, request: Request<AsyncBody>, ctx: Context<'a>) -> InterceptorFuture<'a, Self::Err> {
         Box::pin(self.0.call(request, ctx))
     }
 }

--- a/src/interceptor/obj.rs
+++ b/src/interceptor/obj.rs
@@ -1,5 +1,5 @@
-use crate::{body::AsyncBody, error::Error};
 use super::{Context, Interceptor, InterceptorFuture};
+use crate::{body::AsyncBody, error::Error};
 use http::Request;
 
 /// Type-erased interceptor object.
@@ -14,7 +14,11 @@ impl InterceptorObj {
 impl Interceptor for InterceptorObj {
     type Err = Error;
 
-    fn intercept<'a>(&'a self, request: Request<AsyncBody>, cx: Context<'a>) -> InterceptorFuture<'a, Self::Err> {
+    fn intercept<'a>(
+        &'a self,
+        request: Request<AsyncBody>,
+        cx: Context<'a>,
+    ) -> InterceptorFuture<'a, Self::Err> {
         self.0.dyn_intercept(request, cx)
     }
 }
@@ -22,13 +26,19 @@ impl Interceptor for InterceptorObj {
 /// Object-safe version of the interceptor used for type erasure. Implementation
 /// detail of [`InterceptorObj`].
 trait DynInterceptor: Send + Sync {
-    fn dyn_intercept<'a>(&'a self, request: Request<AsyncBody>, cx: Context<'a>) -> InterceptorFuture<'a, Error>;
+    fn dyn_intercept<'a>(
+        &'a self,
+        request: Request<AsyncBody>,
+        cx: Context<'a>,
+    ) -> InterceptorFuture<'a, Error>;
 }
 
 impl<I: Interceptor> DynInterceptor for I {
-    fn dyn_intercept<'a>(&'a self, request: Request<AsyncBody>, cx: Context<'a>) -> InterceptorFuture<'a, Error> {
-        Box::pin(async move {
-            self.intercept(request, cx).await.map_err(Error::from_any)
-        })
+    fn dyn_intercept<'a>(
+        &'a self,
+        request: Request<AsyncBody>,
+        cx: Context<'a>,
+    ) -> InterceptorFuture<'a, Error> {
+        Box::pin(async move { self.intercept(request, cx).await.map_err(Error::from_any) })
     }
 }

--- a/src/interceptor/obj.rs
+++ b/src/interceptor/obj.rs
@@ -1,5 +1,5 @@
-use super::{Context, Interceptor, InterceptorFuture};
 use crate::{body::AsyncBody, error::Error};
+use super::{Context, Interceptor, InterceptorFuture};
 use http::Request;
 
 /// Type-erased interceptor object.
@@ -14,11 +14,7 @@ impl InterceptorObj {
 impl Interceptor for InterceptorObj {
     type Err = Error;
 
-    fn intercept<'a>(
-        &'a self,
-        request: Request<AsyncBody>,
-        cx: Context<'a>,
-    ) -> InterceptorFuture<'a, Self::Err> {
+    fn intercept<'a>(&'a self, request: Request<AsyncBody>, cx: Context<'a>) -> InterceptorFuture<'a, Self::Err> {
         self.0.dyn_intercept(request, cx)
     }
 }
@@ -26,19 +22,13 @@ impl Interceptor for InterceptorObj {
 /// Object-safe version of the interceptor used for type erasure. Implementation
 /// detail of [`InterceptorObj`].
 trait DynInterceptor: Send + Sync {
-    fn dyn_intercept<'a>(
-        &'a self,
-        request: Request<AsyncBody>,
-        cx: Context<'a>,
-    ) -> InterceptorFuture<'a, Error>;
+    fn dyn_intercept<'a>(&'a self, request: Request<AsyncBody>, cx: Context<'a>) -> InterceptorFuture<'a, Error>;
 }
 
 impl<I: Interceptor> DynInterceptor for I {
-    fn dyn_intercept<'a>(
-        &'a self,
-        request: Request<AsyncBody>,
-        cx: Context<'a>,
-    ) -> InterceptorFuture<'a, Error> {
-        Box::pin(async move { self.intercept(request, cx).await.map_err(Error::from_any) })
+    fn dyn_intercept<'a>(&'a self, request: Request<AsyncBody>, cx: Context<'a>) -> InterceptorFuture<'a, Error> {
+        Box::pin(async move {
+            self.intercept(request, cx).await.map_err(Error::from_any)
+        })
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -484,11 +484,3 @@ pub fn version() -> &'static str {
 
     &VERSION_STRING
 }
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn test() {
-        // TODO
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,8 +257,8 @@ mod task;
 mod text;
 
 pub mod auth;
-pub mod error;
 pub mod config;
+pub mod error;
 
 #[cfg(feature = "unstable-interceptors")]
 pub mod interceptor;
@@ -288,10 +288,10 @@ pub use http;
 pub mod prelude {
     #[doc(no_inline)]
     pub use crate::{
-        AsyncReadResponseExt,
-        ReadResponseExt,
         config::Configurable,
+        AsyncReadResponseExt,
         HttpClient,
+        ReadResponseExt,
         RequestExt,
         ResponseExt,
     };
@@ -421,7 +421,7 @@ pub fn put_async<U, B>(uri: U, body: B) -> ResponseFuture<'static>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
-    B: Into<AsyncBody>
+    B: Into<AsyncBody>,
 {
     HttpClient::shared().put_async(uri, body)
 }
@@ -473,12 +473,14 @@ pub fn send_async<B: Into<AsyncBody>>(request: Request<B>) -> ResponseFuture<'st
 /// its dependencies.
 pub fn version() -> &'static str {
     static FEATURES_STRING: &str = include_str!(concat!(env!("OUT_DIR"), "/features.txt"));
-    static VERSION_STRING: Lazy<String> = Lazy::new(|| format!(
-        "isahc/{} (features:{}) {}",
-        env!("CARGO_PKG_VERSION"),
-        FEATURES_STRING,
-        curl::Version::num(),
-    ));
+    static VERSION_STRING: Lazy<String> = Lazy::new(|| {
+        format!(
+            "isahc/{} (features:{}) {}",
+            env!("CARGO_PKG_VERSION"),
+            FEATURES_STRING,
+            curl::Version::num(),
+        )
+    });
 
     &VERSION_STRING
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -482,3 +482,11 @@ pub fn version() -> &'static str {
 
     &VERSION_STRING
 }
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test() {
+        // TODO
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -257,8 +257,8 @@ mod task;
 mod text;
 
 pub mod auth;
-pub mod config;
 pub mod error;
+pub mod config;
 
 #[cfg(feature = "unstable-interceptors")]
 pub mod interceptor;
@@ -288,10 +288,10 @@ pub use http;
 pub mod prelude {
     #[doc(no_inline)]
     pub use crate::{
-        config::Configurable,
         AsyncReadResponseExt,
-        HttpClient,
         ReadResponseExt,
+        config::Configurable,
+        HttpClient,
         RequestExt,
         ResponseExt,
     };
@@ -421,7 +421,7 @@ pub fn put_async<U, B>(uri: U, body: B) -> ResponseFuture<'static>
 where
     http::Uri: TryFrom<U>,
     <http::Uri as TryFrom<U>>::Error: Into<http::Error>,
-    B: Into<AsyncBody>,
+    B: Into<AsyncBody>
 {
     HttpClient::shared().put_async(uri, body)
 }
@@ -473,14 +473,12 @@ pub fn send_async<B: Into<AsyncBody>>(request: Request<B>) -> ResponseFuture<'st
 /// its dependencies.
 pub fn version() -> &'static str {
     static FEATURES_STRING: &str = include_str!(concat!(env!("OUT_DIR"), "/features.txt"));
-    static VERSION_STRING: Lazy<String> = Lazy::new(|| {
-        format!(
-            "isahc/{} (features:{}) {}",
-            env!("CARGO_PKG_VERSION"),
-            FEATURES_STRING,
-            curl::Version::num(),
-        )
-    });
+    static VERSION_STRING: Lazy<String> = Lazy::new(|| format!(
+        "isahc/{} (features:{}) {}",
+        env!("CARGO_PKG_VERSION"),
+        FEATURES_STRING,
+        curl::Version::num(),
+    ));
 
     &VERSION_STRING
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,8 +1,5 @@
-use http::{
-    header::{HeaderName, HeaderValue},
-    StatusCode,
-    Version,
-};
+use http::header::{HeaderName, HeaderValue};
+use http::{StatusCode, Version};
 
 pub(crate) fn parse_status_line(line: &[u8]) -> Option<(Version, StatusCode)> {
     let mut parts = line.split(u8::is_ascii_whitespace);
@@ -57,9 +54,7 @@ pub(crate) fn header_to_curl_string(
     value: &HeaderValue,
     title_case: bool,
 ) -> String {
-    let header_value = value
-        .to_str()
-        .expect("request header value is not valid UTF-8!");
+    let header_value = value.to_str().expect("request header value is not valid UTF-8!");
 
     let mut string = String::new();
 
@@ -175,10 +170,7 @@ mod tests {
         let name = "User-Agent".parse().unwrap();
         let value = "foo".parse().unwrap();
 
-        assert_eq!(
-            header_to_curl_string(&name, &value, false),
-            "user-agent:foo"
-        );
+        assert_eq!(header_to_curl_string(&name, &value, false), "user-agent:foo");
     }
 
     #[test]

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -1,5 +1,8 @@
-use http::header::{HeaderName, HeaderValue};
-use http::{StatusCode, Version};
+use http::{
+    header::{HeaderName, HeaderValue},
+    StatusCode,
+    Version,
+};
 
 pub(crate) fn parse_status_line(line: &[u8]) -> Option<(Version, StatusCode)> {
     let mut parts = line.split(u8::is_ascii_whitespace);
@@ -54,7 +57,9 @@ pub(crate) fn header_to_curl_string(
     value: &HeaderValue,
     title_case: bool,
 ) -> String {
-    let header_value = value.to_str().expect("request header value is not valid UTF-8!");
+    let header_value = value
+        .to_str()
+        .expect("request header value is not valid UTF-8!");
 
     let mut string = String::new();
 
@@ -170,7 +175,10 @@ mod tests {
         let name = "User-Agent".parse().unwrap();
         let value = "foo".parse().unwrap();
 
-        assert_eq!(header_to_curl_string(&name, &value, false), "user-agent:foo");
+        assert_eq!(
+            header_to_curl_string(&name, &value, false),
+            "user-agent:foo"
+        );
     }
 
     #[test]

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -88,7 +88,9 @@ impl Interceptor for RedirectInterceptor {
                     // specs don't really say one way or another when this should
                     // happen for most status codes, so we just mimic curl's
                     // behavior here since it is so common.
-                    if response.status() == 301 || response.status() == 302 || response.status() == 303
+                    if response.status() == 301
+                        || response.status() == 302
+                        || response.status() == 303
                     {
                         request_builder = request_builder.method(http::Method::GET);
                     }
@@ -114,12 +116,12 @@ impl Interceptor for RedirectInterceptor {
 
                     // Update the request to point to the new URI.
                     effective_uri = location.clone();
-                    request = request_builder.uri(location)
+                    request = request_builder
+                        .uri(location)
                         .body(request_body)
                         .map_err(|e| Error::new(ErrorKind::InvalidRequest, e))?;
                     redirect_count += 1;
                 }
-
                 // No more redirects; set the effective URI we finally settled on and return.
                 else {
                     response
@@ -138,14 +140,12 @@ fn get_redirect_location<T>(request_uri: &Uri, response: &Response<T>) -> Option
         let location = response.headers().get(http::header::LOCATION)?;
 
         match location.to_str() {
-            Ok(location) => {
-                match resolve(request_uri, location) {
-                    Ok(uri) => return Some(uri),
-                    Err(e) => {
-                        tracing::debug!("bad redirect location: {}", e);
-                    }
+            Ok(location) => match resolve(request_uri, location) {
+                Ok(uri) => return Some(uri),
+                Err(e) => {
+                    tracing::debug!("bad redirect location: {}", e);
                 }
-            }
+            },
             Err(e) => {
                 tracing::debug!("bad redirect location: {}", e);
             }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -88,9 +88,7 @@ impl Interceptor for RedirectInterceptor {
                     // specs don't really say one way or another when this should
                     // happen for most status codes, so we just mimic curl's
                     // behavior here since it is so common.
-                    if response.status() == 301
-                        || response.status() == 302
-                        || response.status() == 303
+                    if response.status() == 301 || response.status() == 302 || response.status() == 303
                     {
                         request_builder = request_builder.method(http::Method::GET);
                     }
@@ -116,12 +114,12 @@ impl Interceptor for RedirectInterceptor {
 
                     // Update the request to point to the new URI.
                     effective_uri = location.clone();
-                    request = request_builder
-                        .uri(location)
+                    request = request_builder.uri(location)
                         .body(request_body)
                         .map_err(|e| Error::new(ErrorKind::InvalidRequest, e))?;
                     redirect_count += 1;
                 }
+
                 // No more redirects; set the effective URI we finally settled on and return.
                 else {
                     response
@@ -140,12 +138,14 @@ fn get_redirect_location<T>(request_uri: &Uri, response: &Response<T>) -> Option
         let location = response.headers().get(http::header::LOCATION)?;
 
         match location.to_str() {
-            Ok(location) => match resolve(request_uri, location) {
-                Ok(uri) => return Some(uri),
-                Err(e) => {
-                    tracing::debug!("bad redirect location: {}", e);
+            Ok(location) => {
+                match resolve(request_uri, location) {
+                    Ok(uri) => return Some(uri),
+                    Err(e) => {
+                        tracing::debug!("bad redirect location: {}", e);
+                    }
                 }
-            },
+            }
             Err(e) => {
                 tracing::debug!("bad redirect location: {}", e);
             }

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,4 +1,7 @@
-use crate::{metrics::Metrics, redirect::EffectiveUri};
+use crate::{
+    metrics::Metrics,
+    redirect::EffectiveUri,
+};
 use futures_lite::io::{AsyncRead, AsyncWrite};
 use http::{Response, Uri};
 use std::{

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,7 +1,4 @@
-use crate::{
-    metrics::Metrics,
-    redirect::EffectiveUri,
-};
+use crate::{metrics::Metrics, redirect::EffectiveUri};
 use futures_lite::io::{AsyncRead, AsyncWrite};
 use http::{Response, Uri};
 use std::{

--- a/src/task.rs
+++ b/src/task.rs
@@ -35,7 +35,9 @@ impl UdpWaker {
         let socket = UdpSocket::bind("127.0.0.1:0")?;
         socket.connect(addr)?;
 
-        Ok(Self { socket })
+        Ok(Self {
+            socket,
+        })
     }
 }
 

--- a/src/task.rs
+++ b/src/task.rs
@@ -35,9 +35,7 @@ impl UdpWaker {
         let socket = UdpSocket::bind("127.0.0.1:0")?;
         socket.connect(addr)?;
 
-        Ok(Self {
-            socket,
-        })
+        Ok(Self { socket })
     }
 }
 

--- a/src/text.rs
+++ b/src/text.rs
@@ -82,7 +82,8 @@ impl Decoder {
 
     /// Create a new encoder suitable for decoding the given response.
     pub(crate) fn for_response<T>(response: &Response<T>) -> Self {
-        if let Some(content_type) = response.content_type()
+        if let Some(content_type) = response
+            .content_type()
             .and_then(|header| header.parse::<mime::Mime>().ok())
         {
             if let Some(charset) = content_type.get_param(mime::CHARSET) {
@@ -110,9 +111,7 @@ impl Decoder {
         R: AsyncRead + Unpin + 'r,
     {
         TextFuture {
-            inner: Box::pin(async move {
-                decode_reader!(self, buf, reader.read(buf).await)
-            }),
+            inner: Box::pin(async move { decode_reader!(self, buf, reader.read(buf).await) }),
             _phantom: PhantomData,
         }
     }

--- a/src/text.rs
+++ b/src/text.rs
@@ -82,8 +82,7 @@ impl Decoder {
 
     /// Create a new encoder suitable for decoding the given response.
     pub(crate) fn for_response<T>(response: &Response<T>) -> Self {
-        if let Some(content_type) = response
-            .content_type()
+        if let Some(content_type) = response.content_type()
             .and_then(|header| header.parse::<mime::Mime>().ok())
         {
             if let Some(charset) = content_type.get_param(mime::CHARSET) {
@@ -111,7 +110,9 @@ impl Decoder {
         R: AsyncRead + Unpin + 'r,
     {
         TextFuture {
-            inner: Box::pin(async move { decode_reader!(self, buf, reader.read(buf).await) }),
+            inner: Box::pin(async move {
+                decode_reader!(self, buf, reader.read(buf).await)
+            }),
             _phantom: PhantomData,
         }
     }

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -1,7 +1,4 @@
-use isahc::{
-    auth::*,
-    prelude::*,
-};
+use isahc::{auth::*, prelude::*};
 use testserver::mock;
 
 #[test]
@@ -31,7 +28,8 @@ fn basic_auth_sends_authorization_header() {
         .unwrap();
 
     // base64
-    m.request().expect_header("authorization", "Basic Y2xhcms6cXVlcnR5");
+    m.request()
+        .expect_header("authorization", "Basic Y2xhcms6cXVlcnR5");
 }
 
 #[cfg(feature = "spnego")]
@@ -72,5 +70,6 @@ fn negotiate_on_windows_provides_a_token() {
         .unwrap();
 
     assert_eq!(response.status(), 200);
-    m.request().expect_header_regex("authorization", r"Negotiate \w+=*");
+    m.request()
+        .expect_header_regex("authorization", r"Negotiate \w+=*");
 }

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -6,7 +6,10 @@ use testserver::mock;
 #[test]
 fn cookie_lifecycle() {
     let jar = CookieJar::default();
-    let client = HttpClient::builder().cookie_jar(jar.clone()).build().unwrap();
+    let client = HttpClient::builder()
+        .cookie_jar(jar.clone())
+        .build()
+        .unwrap();
 
     let m1 = mock! {
         headers {

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -25,7 +25,8 @@ fn gzip_encoded_response_is_decoded_automatically() {
     let mut response = isahc::get(m.url()).unwrap();
 
     assert_eq!(response.text().unwrap(), body);
-    m.request().expect_header("Accept-Encoding", "deflate, gzip");
+    m.request()
+        .expect_header("Accept-Encoding", "deflate, gzip");
 
     // Response body size should be unknown, because the actual content is
     // gzipped.
@@ -87,7 +88,8 @@ fn deflate_encoded_response_is_decoded_automatically() {
     let mut response = isahc::get(m.url()).unwrap();
 
     assert_eq!(response.text().unwrap(), body);
-    m.request().expect_header("Accept-Encoding", "deflate, gzip");
+    m.request()
+        .expect_header("Accept-Encoding", "deflate, gzip");
 
     // Response body size should be unknown, because the actual content is
     // compressed.

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -8,7 +8,8 @@ fn accept_headers_populated_by_default() {
     isahc::get(m.url()).unwrap();
 
     m.request().expect_header("accept", "*/*");
-    m.request().expect_header("accept-encoding", "deflate, gzip");
+    m.request()
+        .expect_header("accept-encoding", "deflate, gzip");
 }
 
 #[test]
@@ -17,7 +18,8 @@ fn user_agent_contains_expected_format() {
 
     isahc::get(m.url()).unwrap();
 
-    m.request().expect_header_regex("user-agent", r"^curl/\S+ isahc/\S+$");
+    m.request()
+        .expect_header_regex("user-agent", r"^curl/\S+ isahc/\S+$");
 }
 
 // Issue [#209](https://github.com/sagebind/isahc/issues/209)
@@ -79,7 +81,9 @@ fn set_title_case_headers_to_true() {
     client.get(m.url()).unwrap();
 
     assert_eq!(m.request().method, "GET");
-    m.request().headers.iter()
+    m.request()
+        .headers
+        .iter()
         .find(|(key, value)| key == "Foo-Bar" && value == "baz")
         .expect("header not found");
 }
@@ -102,7 +106,8 @@ fn header_can_be_inserted_in_httpclient_builder() {
     let _ = client.send(request).unwrap();
 
     m.request().expect_header("accept", "*/*");
-    m.request().expect_header("accept-encoding", "deflate, gzip");
+    m.request()
+        .expect_header("accept-encoding", "deflate, gzip");
     m.request().expect_header("X-header", "some-value1");
 }
 
@@ -125,7 +130,8 @@ fn headers_in_request_builder_must_override_headers_in_httpclient_builder() {
     let _ = client.send(request).unwrap();
 
     m.request().expect_header("accept", "*/*");
-    m.request().expect_header("accept-encoding", "deflate, gzip");
+    m.request()
+        .expect_header("accept-encoding", "deflate, gzip");
     m.request().expect_header("X-header", "some-value2");
 }
 
@@ -148,7 +154,8 @@ fn multiple_headers_with_same_key_can_be_inserted_in_httpclient_builder() {
     let _ = client.send(request).unwrap();
 
     m.request().expect_header("accept", "*/*");
-    m.request().expect_header("accept-encoding", "deflate, gzip");
+    m.request()
+        .expect_header("accept-encoding", "deflate, gzip");
     // Both values should be present.
     m.request().expect_header("X-header", "some-value1");
     m.request().expect_header("X-header", "some-value2");
@@ -174,6 +181,7 @@ fn headers_in_request_builder_must_override_multiple_headers_in_httpclient_build
     let _ = client.send(request).unwrap();
 
     m.request().expect_header("accept", "*/*");
-    m.request().expect_header("accept-encoding", "deflate, gzip");
+    m.request()
+        .expect_header("accept-encoding", "deflate, gzip");
     m.request().expect_header("X-header", "some-value3");
 }

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -19,14 +19,10 @@ fn enabling_metrics_causes_metrics_to_be_collected() {
         body: "hello world",
     };
 
-    let client = isahc::HttpClient::builder()
-        .metrics(true)
-        .build()
-        .unwrap();
+    let client = isahc::HttpClient::builder().metrics(true).build().unwrap();
 
-    let mut response = client.send(Request::post(m.url())
-        .body("hello server")
-        .unwrap())
+    let mut response = client
+        .send(Request::post(m.url()).body("hello server").unwrap())
         .unwrap();
 
     let metrics = response.metrics().unwrap().clone();

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -37,7 +37,8 @@ fn http_proxy() {
     // 7230](https://tools.ietf.org/html/rfc7230), sections 5.3 and 5.7).
     assert_eq!(m.request().url, upstream.to_string());
     // Host should be the upstream authority, not the proxy host.
-    m.request().expect_header("host", upstream.authority().unwrap().as_str());
+    m.request()
+        .expect_header("host", upstream.authority().unwrap().as_str());
     m.request().expect_header("proxy-connection", "Keep-Alive");
 }
 

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -1,8 +1,4 @@
-use isahc::{
-    Body,
-    config::RedirectPolicy,
-    prelude::*,
-};
+use isahc::{config::RedirectPolicy, prelude::*, Body};
 use test_case::test_case;
 use testserver::mock;
 

--- a/tests/request_body.rs
+++ b/tests/request_body.rs
@@ -34,8 +34,10 @@ fn request_with_body_of_known_size(method: &str) {
         .unwrap();
 
     assert_eq!(m.request().method, method);
-    m.request().expect_header("content-length", body.len().to_string());
-    m.request().expect_header("content-type", "application/x-www-form-urlencoded");
+    m.request()
+        .expect_header("content-length", body.len().to_string());
+    m.request()
+        .expect_header("content-type", "application/x-www-form-urlencoded");
     m.request().expect_body(body);
 }
 
@@ -126,14 +128,17 @@ fn upload_from_bad_async_reader_returns_error_with_original_cause() {
     struct BadReader;
 
     impl AsyncRead for BadReader {
-        fn poll_read(self: Pin<&mut Self>, _cx: &mut Context<'_>, _buf: &mut [u8]) -> Poll<io::Result<usize>> {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
             Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into()))
         }
     }
 
-    let result = block_on(async {
-        isahc::put_async(m.url(), AsyncBody::from_reader(BadReader)).await
-    });
+    let result =
+        block_on(async { isahc::put_async(m.url(), AsyncBody::from_reader(BadReader)).await });
 
     assert_matches!(&result, Err(e) if e.kind() == isahc::error::ErrorKind::Io);
     assert_eq!(

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -1,5 +1,9 @@
 use isahc::prelude::*;
-use std::{io::{self, Cursor, Read}, thread, time::Duration};
+use std::{
+    io::{self, Cursor, Read},
+    thread,
+    time::Duration,
+};
 use testserver::mock;
 
 #[macro_use]
@@ -51,5 +55,8 @@ fn timeout_during_response_body_produces_error() {
 
     // Because of the short timeout, the response body should abort while being
     // read from.
-    assert_eq!(response.copy_to(std::io::sink()).unwrap_err().kind(), std::io::ErrorKind::TimedOut);
+    assert_eq!(
+        response.copy_to(std::io::sink()).unwrap_err().kind(),
+        std::io::ErrorKind::TimedOut
+    );
 }

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -9,6 +9,7 @@ use std::{
 use tempfile::TempDir;
 
 #[test]
+#[rustfmt::skip]
 fn send_request_to_unix_socket() {
     let temp_dir = TempDir::new().unwrap();
     let socket_path = temp_dir.path().join("test.sock");
@@ -22,16 +23,12 @@ fn send_request_to_unix_socket() {
             io::copy(&mut reader, &mut io::sink()).unwrap();
         });
 
-        stream
-            .write_all(
-                b"\
+        stream.write_all(b"\
             HTTP/1.1 200 OK\r\n\
             Content-Length: 8\r\n\
             \r\n\
             success\n\
-        ",
-            )
-            .unwrap();
+        ").unwrap();
     });
 
     let mut response = Request::get("http://localhost")

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -1,9 +1,6 @@
 #![cfg(unix)]
 
-use isahc::{
-    prelude::*,
-    config::Dialer,
-};
+use isahc::{config::Dialer, prelude::*};
 use std::{
     io::{self, Write},
     os::unix::net::UnixListener,
@@ -25,12 +22,16 @@ fn send_request_to_unix_socket() {
             io::copy(&mut reader, &mut io::sink()).unwrap();
         });
 
-        stream.write_all(b"\
+        stream
+            .write_all(
+                b"\
             HTTP/1.1 200 OK\r\n\
             Content-Length: 8\r\n\
             \r\n\
             success\n\
-        ").unwrap();
+        ",
+            )
+            .unwrap();
     });
 
     let mut response = Request::get("http://localhost")

--- a/testserver/src/mock.rs
+++ b/testserver/src/mock.rs
@@ -7,11 +7,7 @@
 //! Only HTTP/1.x is implemented, as newer HTTP versions are mostly the same
 //! semantically and are far more complex to deal with.
 
-use crate::{
-    request::Request,
-    responder::*,
-    response::Response,
-};
+use crate::{request::Request, responder::*, response::Response};
 use std::{
     collections::VecDeque,
     io::{Cursor, Read, Write},
@@ -62,10 +58,7 @@ impl<R: Responder> Mock<R> {
 
     /// Get the first request received by this mock.
     pub fn request(&self) -> Request {
-        let request = self.requests.lock()
-            .unwrap()
-            .get(0)
-            .cloned();
+        let request = self.requests.lock().unwrap().get(0).cloned();
 
         request.expect("no request received")
     }
@@ -78,12 +71,14 @@ impl<R: Responder> Mock<R> {
     fn is_ready(&self) -> bool {
         TcpStream::connect(self.addr())
             .and_then(|mut stream| {
-                stream.write_all(b"\
+                stream.write_all(
+                    b"\
                     GET /health HTTP/1.1\r\n\
                     host: api.mock.local\r\n\
                     connection: close\r\n\
                     \r\n\
-                ")?;
+                ",
+                )?;
 
                 let mut response = Vec::new();
                 stream.read_to_end(&mut response)?;
@@ -118,7 +113,12 @@ impl<R: Responder> Mock<R> {
     }
 
     fn handle_request(&self, mut request: tiny_http::Request) {
-        if request.headers().iter().find(|h| h.field.as_str() == "host" && h.value == "api.mock.local").is_some() {
+        if request
+            .headers()
+            .iter()
+            .find(|h| h.field.as_str() == "host" && h.value == "api.mock.local")
+            .is_some()
+        {
             if let Some(response) = self.handle_api_request(&request) {
                 request.respond(response).unwrap();
                 return;
@@ -137,21 +137,28 @@ impl<R: Responder> Mock<R> {
         let mock_request = Request {
             method: request.method().to_string(),
             url: request.url().to_string(),
-            headers: request.headers()
-            .iter()
-            .map(|header| (header.field.to_string(), header.value.to_string()))
-            .collect(),
+            headers: request
+                .headers()
+                .iter()
+                .map(|header| (header.field.to_string(), header.value.to_string()))
+                .collect(),
             body: Some(body),
         };
 
-        self.requests.lock().unwrap().push_back(mock_request.clone());
+        self.requests
+            .lock()
+            .unwrap()
+            .push_back(mock_request.clone());
 
         let response = self.respond(mock_request);
 
         request.respond(response.into_http_response()).unwrap();
     }
 
-    fn handle_api_request(&self, request: &tiny_http::Request) -> Option<tiny_http::Response<Cursor<Vec<u8>>>> {
+    fn handle_api_request(
+        &self,
+        request: &tiny_http::Request,
+    ) -> Option<tiny_http::Response<Cursor<Vec<u8>>>> {
         if request.url() == "/health" {
             Some(tiny_http::Response::new(
                 200.into(),

--- a/testserver/src/mock.rs
+++ b/testserver/src/mock.rs
@@ -68,17 +68,16 @@ impl<R: Responder> Mock<R> {
         self.requests.lock().unwrap().iter().cloned().collect()
     }
 
+    #[rustfmt::skip]
     fn is_ready(&self) -> bool {
         TcpStream::connect(self.addr())
             .and_then(|mut stream| {
-                stream.write_all(
-                    b"\
+                stream.write_all(b"\
                     GET /health HTTP/1.1\r\n\
                     host: api.mock.local\r\n\
                     connection: close\r\n\
                     \r\n\
-                ",
-                )?;
+                ")?;
 
                 let mut response = Vec::new();
                 stream.read_to_end(&mut response)?;

--- a/testserver/src/request.rs
+++ b/testserver/src/request.rs
@@ -12,7 +12,8 @@ impl Request {
     pub fn get_header(&self, name: impl AsRef<str>) -> impl Iterator<Item = String> + '_ {
         let name_lower = name.as_ref().to_lowercase();
 
-        self.headers.iter()
+        self.headers
+            .iter()
             .filter(move |(name, _)| name.to_lowercase() == name_lower)
             .map(|(_, value)| value.clone())
     }

--- a/testserver/src/responder.rs
+++ b/testserver/src/responder.rs
@@ -1,7 +1,4 @@
-use crate::{
-    request::Request,
-    response::Response,
-};
+use crate::{request::Request, response::Response};
 
 /// A responder is a request-response handler responsible for producing the
 /// responses returned by a mock endpoint.

--- a/testserver/src/response.rs
+++ b/testserver/src/response.rs
@@ -28,11 +28,11 @@ impl Response {
     pub(crate) fn into_http_response(self) -> tiny_http::Response<Box<dyn Read>> {
         tiny_http::Response::new(
             self.status_code.into(),
-            self.headers.into_iter()
-                .map(|(name, value)| tiny_http::Header::from_bytes(
-                    name.as_bytes(),
-                    value.as_bytes(),
-                ).unwrap())
+            self.headers
+                .into_iter()
+                .map(|(name, value)| {
+                    tiny_http::Header::from_bytes(name.as_bytes(), value.as_bytes()).unwrap()
+                })
                 .collect(),
             self.body,
             self.body_len,


### PR DESCRIPTION
Apply newly added rustfmt configuration from #276 to the entire repo. This will be the start of a clean slate going forward for consistent formatting.

In addition, this PR is to test semi-automated formatting with the `@teto-bot rustfmt` command, which can be invoked from any PR by the PR author or by an Isahc maintainer. Indeed, the formatting proposed by this PR was all automated.