### PR TITLE
Remove structs from prelude module

### DIFF
--- a/examples/badssl.rs
+++ b/examples/badssl.rs
@@ -1,7 +1,7 @@
 //! This example contains a number of manual tests against badssl.com
 //! demonstrating several dangerous SSL/TLS options.
 
-use isahc::{config::SslOption, prelude::*};
+use isahc::{config::SslOption, prelude::*, Request};
 
 fn main() {
     // accept expired cert

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,7 +1,7 @@
 //! Another simple example that creates a custom HTTP client instance and sends
 //! a GET request with it instead of using the default client.
 
-use isahc::{config::RedirectPolicy, prelude::*};
+use isahc::{config::RedirectPolicy, prelude::*, HttpClient};
 use std::{
     io::{copy, stdout},
     time::Duration,

--- a/examples/cookies.rs
+++ b/examples/cookies.rs
@@ -1,7 +1,7 @@
 //! A simple example program that sends a GET request and then prints out all
 //! the cookies in the cookie jar.
 
-use isahc::{cookies::CookieJar, prelude::*};
+use isahc::{cookies::CookieJar, prelude::*, Request};
 use std::error::Error;
 
 fn main() -> Result<(), Box<dyn Error>> {

--- a/examples/http2.rs
+++ b/examples/http2.rs
@@ -1,7 +1,7 @@
 //! This example simply demonstrates HTTP/2 support by making a request that
 //! enforces usage of HTTP/2.
 
-use isahc::{config::VersionNegotiation, prelude::*};
+use isahc::{config::VersionNegotiation, prelude::*, Request};
 
 fn main() -> Result<(), isahc::Error> {
     let response = Request::get("https://nghttp2.org")

--- a/examples/parallel_requests.rs
+++ b/examples/parallel_requests.rs
@@ -6,7 +6,7 @@
 //!
 //! [rayon]: https://github.com/rayon-rs/rayon
 
-use isahc::prelude::*;
+use isahc::HttpClient;
 use rayon::prelude::*;
 use std::{env, time::Instant};
 

--- a/examples/progress.rs
+++ b/examples/progress.rs
@@ -10,7 +10,7 @@
 //! [structopt]: https://github.com/TeXitoi/structopt
 
 use indicatif::{FormattedDuration, HumanBytes, ProgressBar, ProgressStyle};
-use isahc::prelude::*;
+use isahc::{prelude::*, Request};
 use std::io::Read;
 use structopt::StructOpt;
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -56,8 +56,11 @@ static USER_AGENT: Lazy<String> = Lazy::new(|| {
 /// # Examples
 ///
 /// ```
-/// use isahc::config::{RedirectPolicy, VersionNegotiation};
-/// use isahc::prelude::*;
+/// use isahc::{
+///     config::{RedirectPolicy, VersionNegotiation},
+///     prelude::*,
+///     HttpClient,
+/// };
 /// use std::time::Duration;
 ///
 /// let client = HttpClient::builder()
@@ -126,8 +129,8 @@ impl HttpClientBuilder {
     /// # Examples
     ///
     /// ```no_run
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{prelude::*, HttpClient};
+    ///
     /// // Create a client with a cookie jar.
     /// let client = HttpClient::builder()
     ///     .cookies()
@@ -267,10 +270,9 @@ impl HttpClientBuilder {
     /// # Examples
     ///
     /// ```
-    /// # use isahc::config::*;
-    /// # use isahc::prelude::*;
-    /// # use std::time::Duration;
-    /// #
+    /// use isahc::{config::*, prelude::*, HttpClient};
+    /// use std::time::Duration;
+    ///
     /// let client = HttpClient::builder()
     ///     // Cache entries for 10 seconds.
     ///     .dns_cache(Duration::from_secs(10))
@@ -300,10 +302,9 @@ impl HttpClientBuilder {
     /// # Examples
     ///
     /// ```
-    /// # use isahc::config::ResolveMap;
-    /// # use isahc::prelude::*;
-    /// # use std::net::IpAddr;
-    /// #
+    /// use isahc::{config::ResolveMap, prelude::*, HttpClient};
+    /// use std::net::IpAddr;
+    ///
     /// let client = HttpClient::builder()
     ///     .dns_resolve(ResolveMap::new()
     ///         // Send requests for example.org on port 80 to 127.0.0.1.
@@ -333,8 +334,8 @@ impl HttpClientBuilder {
     /// # Examples
     ///
     /// ```
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{prelude::*, HttpClient};
+    ///
     /// let client = HttpClient::builder()
     ///     .default_header("some-header", "some-value")
     ///     .build()?;
@@ -377,8 +378,8 @@ impl HttpClientBuilder {
     /// Set default headers from a slice:
     ///
     /// ```
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{prelude::*, HttpClient};
+    ///
     /// let mut builder = HttpClient::builder()
     ///     .default_headers(&[
     ///         ("some-header", "value1"),
@@ -392,8 +393,8 @@ impl HttpClientBuilder {
     /// Using an existing header map:
     ///
     /// ```
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{prelude::*, HttpClient};
+    ///
     /// let mut headers = http::HeaderMap::new();
     /// headers.append("some-header".parse::<http::header::HeaderName>()?, "some-value".parse()?);
     ///
@@ -406,9 +407,9 @@ impl HttpClientBuilder {
     /// Using a hashmap:
     ///
     /// ```
-    /// # use isahc::prelude::*;
-    /// # use std::collections::HashMap;
-    /// #
+    /// use isahc::{prelude::*, HttpClient};
+    /// use std::collections::HashMap;
+    ///
     /// let mut headers = HashMap::new();
     /// headers.insert("some-header", "some-value");
     ///
@@ -556,7 +557,7 @@ impl<'a, K: Copy, V: Copy> HeaderPair<K, V> for &'a (K, V) {
 /// # Examples
 ///
 /// ```no_run
-/// use isahc::prelude::*;
+/// use isahc::{prelude::*, HttpClient};
 ///
 /// // Create a new client using reasonable defaults.
 /// let client = HttpClient::new()?;
@@ -575,6 +576,7 @@ impl<'a, K: Copy, V: Copy> HeaderPair<K, V> for &'a (K, V) {
 /// use isahc::{
 ///     config::{RedirectPolicy, VersionNegotiation},
 ///     prelude::*,
+///     HttpClient,
 /// };
 /// use std::time::Duration;
 ///
@@ -656,9 +658,9 @@ impl HttpClient {
     /// # Examples
     ///
     /// ```no_run
-    /// use isahc::prelude::*;
+    /// use isahc::{prelude::*, HttpClient};
     ///
-    /// # let client = HttpClient::new()?;
+    /// let client = HttpClient::new()?;
     /// let mut response = client.get("https://example.org")?;
     /// println!("{}", response.text()?);
     /// # Ok::<(), isahc::Error>(())
@@ -698,8 +700,9 @@ impl HttpClient {
     /// # Examples
     ///
     /// ```no_run
-    /// # use isahc::prelude::*;
-    /// # let client = HttpClient::new()?;
+    /// use isahc::{prelude::*, HttpClient};
+    ///
+    /// let client = HttpClient::new()?;
     /// let response = client.head("https://example.org")?;
     /// println!("Page size: {:?}", response.headers()["content-length"]);
     /// # Ok::<(), isahc::Error>(())
@@ -739,7 +742,7 @@ impl HttpClient {
     /// # Examples
     ///
     /// ```no_run
-    /// use isahc::prelude::*;
+    /// use isahc::{prelude::*, HttpClient};
     ///
     /// let client = HttpClient::new()?;
     ///
@@ -786,7 +789,7 @@ impl HttpClient {
     /// # Examples
     ///
     /// ```no_run
-    /// use isahc::prelude::*;
+    /// use isahc::{prelude::*, HttpClient};
     ///
     /// let client = HttpClient::new()?;
     ///
@@ -859,38 +862,35 @@ impl HttpClient {
 
     /// Send an HTTP request and return the HTTP response.
     ///
-    /// The response body is provided as a stream that may only be consumed
-    /// once.
-    ///
-    /// This client's configuration can be overridden for this request by
-    /// configuring the request using methods provided by the [`Configurable`]
-    /// trait.
-    ///
     /// Upon success, will return a [`Response`] containing the status code,
     /// response headers, and response body from the server. The [`Response`] is
     /// returned as soon as the HTTP response headers are received; the
     /// connection will remain open to stream the response body in real time.
-    /// Dropping the response body without fully consume it will close the
+    /// Dropping the response body without fully consuming it will close the
     /// connection early without downloading the rest of the response body.
     ///
-    /// _Note that the actual underlying socket connection isn't necessarily
-    /// closed on drop. It may remain open to be reused if pipelining is being
-    /// used, the connection is configured as `keep-alive`, and so on._
-    ///
-    /// Since the response body is streamed from the server, it may only be
-    /// consumed once. If you need to inspect the response body more than once,
-    /// you will have to either read it into memory or write it to a file.
+    /// The response body is provided as a stream that may only be consumed
+    /// once. If you need to inspect the response body more than once, you will
+    /// have to either read it into memory or write it to a file.
     ///
     /// The response body is not a direct stream from the server, but uses its
     /// own buffering mechanisms internally for performance. It is therefore
     /// undesirable to wrap the body in additional buffering readers.
     ///
-    /// To execute the request asynchronously, see [`HttpClient::send_async`].
+    /// _Note that the actual underlying socket connection isn't necessarily
+    /// closed on drop. It may remain open to be reused if pipelining is being
+    /// used, the connection is configured as `keep-alive`, and so on._
+    ///
+    /// This client's configuration can be overridden for this request by
+    /// configuring the request using methods provided by the [`Configurable`]
+    /// trait.
+    ///
+    /// To execute a request asynchronously, see [`HttpClient::send_async`].
     ///
     /// # Examples
     ///
     /// ```no_run
-    /// use isahc::prelude::*;
+    /// use isahc::{prelude::*, HttpClient, Request};
     ///
     /// let client = HttpClient::new()?;
     ///
@@ -951,13 +951,36 @@ impl HttpClient {
 
     /// Send an HTTP request and return the HTTP response asynchronously.
     ///
-    /// See [`HttpClient::send`] for further details.
+    /// Upon success, will return a [`Response`] containing the status code,
+    /// response headers, and response body from the server. The [`Response`] is
+    /// returned as soon as the HTTP response headers are received; the
+    /// connection will remain open to stream the response body in real time.
+    /// Dropping the response body without fully consuming it will close the
+    /// connection early without downloading the rest of the response body.
+    ///
+    /// The response body is provided as a stream that may only be consumed
+    /// once. If you need to inspect the response body more than once, you will
+    /// have to either read it into memory or write it to a file.
+    ///
+    /// The response body is not a direct stream from the server, but uses its
+    /// own buffering mechanisms internally for performance. It is therefore
+    /// undesirable to wrap the body in additional buffering readers.
+    ///
+    /// _Note that the actual underlying socket connection isn't necessarily
+    /// closed on drop. It may remain open to be reused if pipelining is being
+    /// used, the connection is configured as `keep-alive`, and so on._
+    ///
+    /// This client's configuration can be overridden for this request by
+    /// configuring the request using methods provided by the [`Configurable`]
+    /// trait.
+    ///
+    /// To execute a request synchronously, see [`HttpClient::send`].
     ///
     /// # Examples
     ///
     /// ```no_run
     /// # async fn run() -> Result<(), isahc::Error> {
-    /// use isahc::prelude::*;
+    /// use isahc::{prelude::*, HttpClient, Request};
     ///
     /// let client = HttpClient::new()?;
     ///

--- a/src/client.rs
+++ b/src/client.rs
@@ -1181,10 +1181,10 @@ impl HttpClient {
 }
 
 impl crate::interceptor::Invoke for &HttpClient {
-    fn invoke<'a>(
-        &'a self,
+    fn invoke(
+        &self,
         mut request: Request<AsyncBody>,
-    ) -> crate::interceptor::InterceptorFuture<'a, Error> {
+    ) -> crate::interceptor::InterceptorFuture<'_, Error> {
         Box::pin(async move {
             // Set default user agent if not specified.
             request

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -62,7 +62,7 @@ pub trait Configurable: internal::ConfigurableBase {
     /// # Examples
     ///
     /// ```no_run
-    /// use isahc::prelude::*;
+    /// use isahc::{prelude::*, Request};
     /// use std::time::Duration;
     ///
     /// // This page is too slow and won't respond in time.
@@ -92,8 +92,12 @@ pub trait Configurable: internal::ConfigurableBase {
     /// # Examples
     ///
     /// ```
-    /// use isahc::config::VersionNegotiation;
-    /// use isahc::prelude::*;
+    /// use isahc::{
+    ///     config::VersionNegotiation,
+    ///     prelude::*,
+    ///     HttpClient,
+    /// };
+    ///
     /// // Never use anything newer than HTTP/1.x for this client.
     /// let http11_client = HttpClient::builder()
     ///     .version_negotiation(VersionNegotiation::http11())
@@ -116,8 +120,7 @@ pub trait Configurable: internal::ConfigurableBase {
     /// # Examples
     ///
     /// ```no_run
-    /// use isahc::config::RedirectPolicy;
-    /// use isahc::prelude::*;
+    /// use isahc::{config::RedirectPolicy, prelude::*, Request};
     ///
     /// // This URL redirects us to where we want to go.
     /// let response = Request::get("https://httpbin.org/redirect/1")
@@ -186,9 +189,12 @@ pub trait Configurable: internal::ConfigurableBase {
     /// # Examples
     ///
     /// ```
-    /// # use isahc::auth::*;
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{
+    ///     auth::{Authentication, Credentials},
+    ///     prelude::*,
+    ///     HttpClient,
+    /// };
+    ///
     /// let client = HttpClient::builder()
     ///     .authentication(Authentication::basic() | Authentication::digest())
     ///     .credentials(Credentials::new("clark", "qwerty"))
@@ -227,6 +233,8 @@ pub trait Configurable: internal::ConfigurableBase {
     /// use isahc::{
     ///     prelude::*,
     ///     config::NetworkInterface,
+    ///     HttpClient,
+    ///     Request,
     /// };
     /// use std::net::IpAddr;
     ///
@@ -274,6 +282,7 @@ pub trait Configurable: internal::ConfigurableBase {
     /// use isahc::{
     ///     config::Dialer,
     ///     prelude::*,
+    ///     Request,
     /// };
     ///
     /// # #[cfg(unix)]
@@ -289,6 +298,7 @@ pub trait Configurable: internal::ConfigurableBase {
     /// use isahc::{
     ///     config::Dialer,
     ///     prelude::*,
+    ///     Request,
     /// };
     /// use std::net::Ipv4Addr;
     ///
@@ -325,9 +335,8 @@ pub trait Configurable: internal::ConfigurableBase {
     /// Using `http://proxy:80` as a proxy:
     ///
     /// ```
-    /// # use isahc::auth::*;
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{prelude::*, HttpClient};
+    ///
     /// let client = HttpClient::builder()
     ///     .proxy(Some("http://proxy:80".parse()?))
     ///     .build()?;
@@ -337,8 +346,8 @@ pub trait Configurable: internal::ConfigurableBase {
     /// Explicitly disable the use of a proxy:
     ///
     /// ```
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{prelude::*, HttpClient};
+    ///
     /// let client = HttpClient::builder()
     ///     .proxy(None)
     ///     .build()?;
@@ -353,8 +362,8 @@ pub trait Configurable: internal::ConfigurableBase {
     /// # Examples
     ///
     /// ```
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{prelude::*, HttpClient};
+    ///
     /// let client = HttpClient::builder()
     ///     // Disable proxy for specified hosts.
     ///     .proxy_blacklist(vec!["a.com", "b.org"])
@@ -379,9 +388,12 @@ pub trait Configurable: internal::ConfigurableBase {
     /// # Examples
     ///
     /// ```
-    /// # use isahc::auth::*;
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{
+    ///     auth::{Authentication, Credentials},
+    ///     prelude::*,
+    ///     HttpClient,
+    /// };
+    ///
     /// let client = HttpClient::builder()
     ///     .proxy("http://proxy:80".parse::<http::Uri>()?)
     ///     .proxy_authentication(Authentication::basic())
@@ -427,8 +439,11 @@ pub trait Configurable: internal::ConfigurableBase {
     /// # Examples
     ///
     /// ```no_run
-    /// use isahc::config::{ClientCertificate, PrivateKey};
-    /// use isahc::prelude::*;
+    /// use isahc::{
+    ///     config::{ClientCertificate, PrivateKey},
+    ///     prelude::*,
+    ///     Request,
+    /// };
     ///
     /// let response = Request::get("localhost:3999")
     ///     .ssl_client_certificate(ClientCertificate::pem_file(
@@ -441,9 +456,12 @@ pub trait Configurable: internal::ConfigurableBase {
     /// ```
     ///
     /// ```
-    /// # use isahc::config::*;
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{
+    ///     config::{ClientCertificate, PrivateKey},
+    ///     prelude::*,
+    ///     HttpClient,
+    /// };
+    ///
     /// let client = HttpClient::builder()
     ///     .ssl_client_certificate(ClientCertificate::pem_file(
     ///         "client.pem",
@@ -470,9 +488,8 @@ pub trait Configurable: internal::ConfigurableBase {
     /// # Examples
     ///
     /// ```
-    /// # use isahc::config::*;
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{config::CaCertificate, prelude::*, HttpClient};
+    ///
     /// let client = HttpClient::builder()
     ///     .ssl_ca_certificate(CaCertificate::file("ca.pem"))
     ///     .build()?;
@@ -514,9 +531,8 @@ pub trait Configurable: internal::ConfigurableBase {
     /// # Examples
     ///
     /// ```
-    /// # use isahc::config::*;
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{config::SslOption, prelude::*, Request};
+    ///
     /// let response = Request::get("https://badssl.com")
     ///     .ssl_options(SslOption::DANGER_ACCEPT_INVALID_CERTS | SslOption::DANGER_ACCEPT_REVOKED_CERTS)
     ///     .body(())?
@@ -525,9 +541,8 @@ pub trait Configurable: internal::ConfigurableBase {
     /// ```
     ///
     /// ```
-    /// # use isahc::config::*;
-    /// # use isahc::prelude::*;
-    /// #
+    /// use isahc::{config::SslOption, prelude::*, HttpClient};
+    ///
     /// let client = HttpClient::builder()
     ///     .ssl_options(SslOption::DANGER_ACCEPT_INVALID_CERTS | SslOption::DANGER_ACCEPT_REVOKED_CERTS)
     ///     .build()?;

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,7 +16,7 @@
 use self::internal::SetOpt;
 use crate::auth::{Authentication, Credentials};
 use curl::easy::Easy2;
-use std::{iter::FromIterator, net::IpAddr, time::Duration};
+use std::{net::IpAddr, time::Duration};
 
 pub(crate) mod dial;
 pub(crate) mod dns;
@@ -375,7 +375,7 @@ pub trait Configurable: internal::ConfigurableBase {
         I: IntoIterator<Item = T>,
         T: Into<String>,
     {
-        self.configure(proxy::Blacklist::from_iter(hosts.into_iter().map(T::into)))
+        self.configure(hosts.into_iter().map(T::into).collect::<proxy::Blacklist>())
     }
 
     /// Set one or more HTTP authentication methods to attempt to use when
@@ -511,7 +511,7 @@ pub trait Configurable: internal::ConfigurableBase {
         I: IntoIterator<Item = T>,
         T: Into<String>,
     {
-        self.configure(ssl::Ciphers::from_iter(ciphers.into_iter().map(T::into)))
+        self.configure(ciphers.into_iter().map(T::into).collect::<ssl::Ciphers>())
     }
 
     /// Set various options for this request that control SSL/TLS behavior.

--- a/src/interceptor/context.rs
+++ b/src/interceptor/context.rs
@@ -33,5 +33,5 @@ impl fmt::Debug for Context<'_> {
 }
 
 pub(crate) trait Invoke {
-    fn invoke<'a>(&'a self, request: Request<AsyncBody>) -> InterceptorFuture<'a, Error>;
+    fn invoke(&self, request: Request<AsyncBody>) -> InterceptorFuture<'_, Error>;
 }

--- a/src/request.rs
+++ b/src/request.rs
@@ -22,7 +22,7 @@ pub trait RequestExt<T> {
     /// # Examples
     ///
     /// ```no_run
-    /// use isahc::prelude::*;
+    /// use isahc::{prelude::*, Request};
     ///
     /// let response = Request::post("https://httpbin.org/post")
     ///     .header("Content-Type", "application/json")

--- a/tests/auth.rs
+++ b/tests/auth.rs
@@ -1,4 +1,4 @@
-use isahc::{auth::*, prelude::*};
+use isahc::{auth::*, prelude::*, Request};
 use testserver::mock;
 
 #[test]

--- a/tests/cookies.rs
+++ b/tests/cookies.rs
@@ -1,6 +1,6 @@
 #![cfg(feature = "cookies")]
 
-use isahc::{cookies::CookieJar, prelude::*};
+use isahc::{cookies::CookieJar, prelude::*, HttpClient};
 use testserver::mock;
 
 #[test]

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -2,7 +2,7 @@ use flate2::{
     read::{DeflateEncoder, GzEncoder},
     Compression,
 };
-use isahc::prelude::*;
+use isahc::{prelude::*, Request};
 use std::io::Read;
 use testserver::mock;
 

--- a/tests/headers.rs
+++ b/tests/headers.rs
@@ -1,4 +1,4 @@
-use isahc::prelude::*;
+use isahc::{prelude::*, HttpClient, Request};
 use testserver::mock;
 
 #[test]

--- a/tests/methods.rs
+++ b/tests/methods.rs
@@ -1,4 +1,4 @@
-use isahc::prelude::*;
+use isahc::{prelude::*, Request};
 use testserver::mock;
 
 #[test]

--- a/tests/metrics.rs
+++ b/tests/metrics.rs
@@ -1,4 +1,4 @@
-use isahc::prelude::*;
+use isahc::{prelude::*, HttpClient, Request};
 use std::{io, time::Duration};
 use testserver::mock;
 
@@ -19,7 +19,7 @@ fn enabling_metrics_causes_metrics_to_be_collected() {
         body: "hello world",
     };
 
-    let client = isahc::HttpClient::builder().metrics(true).build().unwrap();
+    let client = HttpClient::builder().metrics(true).build().unwrap();
 
     let mut response = client
         .send(Request::post(m.url()).body("hello server").unwrap())

--- a/tests/proxy.rs
+++ b/tests/proxy.rs
@@ -1,4 +1,4 @@
-use isahc::prelude::*;
+use isahc::{prelude::*, Request};
 use testserver::{mock, socks4::Socks4Server};
 
 #[test]

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -1,4 +1,4 @@
-use isahc::{config::RedirectPolicy, prelude::*, Body};
+use isahc::{config::RedirectPolicy, prelude::*, Body, HttpClient, Request};
 use test_case::test_case;
 use testserver::mock;
 

--- a/tests/request_body.rs
+++ b/tests/request_body.rs
@@ -1,5 +1,5 @@
 use futures_lite::{future::block_on, AsyncRead};
-use isahc::{prelude::*, AsyncBody, Body};
+use isahc::{prelude::*, AsyncBody, Body, Request};
 use std::{
     error::Error,
     io::{self, Read},

--- a/tests/timeouts.rs
+++ b/tests/timeouts.rs
@@ -1,4 +1,4 @@
-use isahc::prelude::*;
+use isahc::{prelude::*, Request};
 use std::{
     io::{self, Cursor, Read},
     thread,

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -1,6 +1,6 @@
 #![cfg(unix)]
 
-use isahc::{config::Dialer, prelude::*};
+use isahc::{config::Dialer, prelude::*, Request};
 use std::{
     io::{self, Write},
     os::unix::net::UnixListener,


### PR DESCRIPTION
Remove `Request`, `Response`, and `HttpClient` from the prelude since aren't really ubiquitous enough to deserve that position and glob-importing structs can be more confusing to beginners not sure where a type comes from.

Also clean up some doc examples to show imports to aid in understandability.