### PR TITLE
Update future types to be Send

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,12 +33,12 @@ macro_rules! decl_future {
             $(#[$meta])*
             #[allow(missing_debug_implementations, non_snake_case)]
             #[must_use = "futures do nothing unless you `.await` or poll them"]
-            $vis struct $ident<'a $($(, $T)*)*> {
+            $vis struct $ident<'a, $($($T),*)*> {
                 inner: ::std::pin::Pin<Box<dyn ::std::future::Future<Output = $output> + 'a>>,
                 $($($T: ::std::marker::PhantomData<$T>,)*)*
             }
 
-            impl<'a, $($($T)*)*> $ident<'a, $($($T)*)*> {
+            impl<'a, $($($T),*)*> $ident<'a, $($($T),*)*> {
                 pub(crate) fn new<F>(future: F) -> Self
                 where
                 F: ::std::future::Future<Output = $output> + 'a,
@@ -50,7 +50,7 @@ macro_rules! decl_future {
                 }
             }
 
-            impl<$($($T: Unpin)*)*> ::std::future::Future for $ident<'_, $($($T)*)*> {
+            impl<$($($T: Unpin),*)*> ::std::future::Future for $ident<'_, $($($T),*)*> {
                 type Output = $output;
 
                 fn poll(mut self: ::std::pin::Pin<&mut Self>, cx: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
@@ -60,7 +60,7 @@ macro_rules! decl_future {
 
             $(
                 #[allow(unsafe_code)]
-                unsafe impl<$($S: Send),*> Send for $ident<'_, $($S)*> {}
+                unsafe impl<$($S: Send),*> Send for $ident<'_, $($S),*> {}
             )*
         )*
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -21,3 +21,47 @@ macro_rules! match_type {
         }
     }};
 }
+
+macro_rules! decl_future {
+    (
+        $(
+            $(#[$meta:meta])*
+            $vis:vis type $ident:ident$(<$($T:ident),*>)? = impl Future<Output = $output:ty> $(+ SendIf<$($S:ident),+>)?;
+        )*
+    ) => {
+        $(
+            $(#[$meta])*
+            #[allow(missing_debug_implementations, non_snake_case)]
+            #[must_use = "futures do nothing unless you `.await` or poll them"]
+            $vis struct $ident<'a $($(, $T)*)*> {
+                inner: ::std::pin::Pin<Box<dyn ::std::future::Future<Output = $output> + 'a>>,
+                $($($T: ::std::marker::PhantomData<$T>,)*)*
+            }
+
+            impl<'a, $($($T)*)*> $ident<'a, $($($T)*)*> {
+                pub(crate) fn new<F>(future: F) -> Self
+                where
+                F: ::std::future::Future<Output = $output> + 'a,
+                {
+                    Self {
+                        inner: Box::pin(future),
+                        $($($T: ::std::marker::PhantomData,)*)*
+                    }
+                }
+            }
+
+            impl<$($($T: Unpin)*)*> ::std::future::Future for $ident<'_, $($($T)*)*> {
+                type Output = $output;
+
+                fn poll(mut self: ::std::pin::Pin<&mut Self>, cx: &mut ::std::task::Context<'_>) -> ::std::task::Poll<Self::Output> {
+                    self.as_mut().inner.as_mut().poll(cx)
+                }
+            }
+
+            $(
+                #[allow(unsafe_code)]
+                unsafe impl<$($S: Send),*> Send for $ident<'_, $($S)*> {}
+            )*
+        )*
+    };
+}

--- a/src/response.rs
+++ b/src/response.rs
@@ -91,7 +91,7 @@ impl<T> ResponseExt<T> for Response<T> {
 }
 
 /// Provides extension methods for consuming HTTP response streams.
-pub trait ReadResponseExt<T: Read> {
+pub trait ReadResponseExt<R: Read> {
     /// Copy the response body into a writer.
     ///
     /// Returns the number of bytes that were written.
@@ -187,7 +187,7 @@ pub trait ReadResponseExt<T: Read> {
         D: serde::de::DeserializeOwned;
 }
 
-impl<T: Read> ReadResponseExt<T> for Response<T> {
+impl<R: Read> ReadResponseExt<R> for Response<R> {
     fn copy_to<W: Write>(&mut self, mut writer: W) -> io::Result<u64> {
         io::copy(self.body_mut(), &mut writer)
     }
@@ -207,7 +207,7 @@ impl<T: Read> ReadResponseExt<T> for Response<T> {
 }
 
 /// Provides extension methods for consuming asynchronous HTTP response streams.
-pub trait AsyncReadResponseExt<T: AsyncRead + Unpin> {
+pub trait AsyncReadResponseExt<R: AsyncRead + Unpin> {
     /// Copy the response body into a writer asynchronously.
     ///
     /// Returns the number of bytes that were written.
@@ -226,7 +226,7 @@ pub trait AsyncReadResponseExt<T: AsyncRead + Unpin> {
     /// println!("Read {} bytes", buf.len());
     /// # Ok(()) }
     /// ```
-    fn copy_to<'a, W>(&'a mut self, writer: W) -> CopyFuture<'a, T>
+    fn copy_to<'a, W>(&'a mut self, writer: W) -> CopyFuture<'a, R, W>
     where
         W: AsyncWrite + Unpin + 'a;
 
@@ -253,11 +253,11 @@ pub trait AsyncReadResponseExt<T: AsyncRead + Unpin> {
     /// # Ok(()) }
     /// ```
     #[cfg(feature = "text-decoding")]
-    fn text(&mut self) -> crate::text::TextFuture<'_, &mut T>;
+    fn text(&mut self) -> crate::text::TextFuture<'_, &mut R>;
 }
 
-impl<T: AsyncRead + Unpin> AsyncReadResponseExt<T> for Response<T> {
-    fn copy_to<'a, W>(&'a mut self, writer: W) -> CopyFuture<'a, T>
+impl<R: AsyncRead + Unpin> AsyncReadResponseExt<R> for Response<R> {
+    fn copy_to<'a, W>(&'a mut self, writer: W) -> CopyFuture<'a, R, W>
     where
         W: AsyncWrite + Unpin + 'a,
     {
@@ -265,14 +265,14 @@ impl<T: AsyncRead + Unpin> AsyncReadResponseExt<T> for Response<T> {
     }
 
     #[cfg(feature = "text-decoding")]
-    fn text(&mut self) -> crate::text::TextFuture<'_, &mut T> {
+    fn text(&mut self) -> crate::text::TextFuture<'_, &mut R> {
         crate::text::Decoder::for_response(&self).decode_reader_async(self.body_mut())
     }
 }
 
 decl_future! {
     /// A future which copies all the response body bytes into a sink.
-    pub type CopyFuture<T> = impl Future<Output = io::Result<u64>> + SendIf<T>;
+    pub type CopyFuture<R, W> = impl Future<Output = io::Result<u64>> + SendIf<R, W>;
 }
 
 pub(crate) struct LocalAddr(pub(crate) SocketAddr);
@@ -283,6 +283,10 @@ pub(crate) struct RemoteAddr(pub(crate) SocketAddr);
 mod tests {
     use super::*;
 
-    static_assertions::assert_impl_all!(CopyFuture<'static, Vec<u8>>: Send);
-    static_assertions::assert_not_impl_any!(CopyFuture<'static, *mut Vec<u8>>: Send);
+    static_assertions::assert_impl_all!(CopyFuture<'static, Vec<u8>, Vec<u8>>: Send);
+
+    // *mut T is !Send
+    static_assertions::assert_not_impl_any!(CopyFuture<'static, *mut Vec<u8>, Vec<u8>>: Send);
+    static_assertions::assert_not_impl_any!(CopyFuture<'static, Vec<u8>, *mut Vec<u8>>: Send);
+    static_assertions::assert_not_impl_any!(CopyFuture<'static, *mut Vec<u8>, *mut Vec<u8>>: Send);
 }


### PR DESCRIPTION
Update future types used by `AsyncReadResponseExt` to be `Send` whenever `T` is `Send` as appropriate. Consolidate the newtype futures with a macro that handles conditional `Send` properly to reduce boilerplate and chance of mistakes.

Fixes #283.