### PR TITLE
Always use a single space after colon for HTTP 1 headers

### DIFF
--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -177,7 +177,7 @@ mod tests {
 
         assert_eq!(
             header_to_curl_string(&name, &value, false),
-            "user-agent:foo"
+            "user-agent: foo"
         );
     }
 
@@ -194,6 +194,6 @@ mod tests {
         let name = "User-Agent".parse().unwrap();
         let value = "foo".parse().unwrap();
 
-        assert_eq!(header_to_curl_string(&name, &value, true), "User-Agent:foo");
+        assert_eq!(header_to_curl_string(&name, &value, true), "User-Agent: foo");
     }
 }

--- a/src/parsing.rs
+++ b/src/parsing.rs
@@ -85,7 +85,7 @@ pub(crate) fn header_to_curl_string(
     if header_value.trim().is_empty() {
         string.push(';');
     } else {
-        string.push(':');
+        string.push_str(": ");
         string.push_str(header_value);
     }
 


### PR DESCRIPTION
Previously headers were sent with no whitespace before or after the colon (`:`). This is legal according to RFC 7230, section 3.2, but is somewhat unusual and can cause poorly-written servers to choke on parsing the request. Update the encoder to always add a single space after the colon to be in line with what most parsers should expect.

This has no effect on HTTP/2 or newer, since they use a binary format for headers.

Fixes #286.