### PR TITLE
Fix parsing of quoted cookie values

### DIFF
--- a/src/cookies/cookie.rs
+++ b/src/cookies/cookie.rs
@@ -227,7 +227,7 @@ impl PartialEq<String> for Cookie {
 fn parse_cookie_value(mut bytes: &[u8]) -> Result<&str, ParseError> {
     // Strip quotes, but only if in a legal pair.
     if bytes.starts_with(b"\"") && bytes.ends_with(b"\"") {
-        bytes = &bytes[1..bytes.len() - 2];
+        bytes = &bytes[1..bytes.len() - 1];
     }
 
     // Validate the bytes are all legal cookie octets.
@@ -301,9 +301,10 @@ mod tests {
         assert!(Cookie::parse(s).is_err());
     }
 
-    #[test]
-    fn parse_simple() {
-        let cookie = Cookie::parse("foo=bar").unwrap();
+    #[test_case("foo=bar")]
+    #[test_case(r#"foo="bar""#)]
+    fn parse_simple(s: &str) {
+        let cookie = Cookie::parse(s).unwrap();
 
         assert_eq!(cookie.name(), "foo");
         assert_eq!(cookie.value(), "bar");


### PR DESCRIPTION
I hit this bug in my project where the cookie value was `""` - just two quote characters.
On checking the code, I figured that this bug might exist for all quoted cookie values.

The test case I had written for quoted cookie values was failing with this error:
```
failures:
---- cookies::cookie::tests::parse_simple::_r_foo_bar_ stdout ----
thread 'cookies::cookie::tests::parse_simple::_r_foo_bar_' panicked at 'assertion failed: `(left == right)`
  left: `"ba"`,
 right: `"bar"`', src\cookies\cookie.rs:310:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Previously one extra character was getting stripped from the end.
This commit fixes the index while stripping the end quote.