### PR TITLE
Add async json response method

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -38,6 +38,7 @@ macro_rules! decl_future {
                 $($($T: ::std::marker::PhantomData<$T>,)*)*
             }
 
+            $(#[$meta])*
             impl<'a, $($($T),*)*> $ident<'a, $($($T),*)*> {
                 pub(crate) fn new<F>(future: F) -> Self
                 where
@@ -50,6 +51,7 @@ macro_rules! decl_future {
                 }
             }
 
+            $(#[$meta])*
             impl<$($($T: Unpin),*)*> ::std::future::Future for $ident<'_, $($($T),*)*> {
                 type Output = $output;
 
@@ -58,6 +60,7 @@ macro_rules! decl_future {
                 }
             }
 
+            $(#[$meta])*
             $(
                 #[allow(unsafe_code)]
                 unsafe impl<$($S: Send),*> Send for $ident<'_, $($S),*> {}

--- a/src/response.rs
+++ b/src/response.rs
@@ -350,6 +350,13 @@ pub trait AsyncReadResponseExt<R: AsyncRead + Unpin> {
 
     /// Deserialize the response body as JSON into a given type.
     ///
+    /// # Caveats
+    ///
+    /// Unlike its [synchronous equivalent](ReadResponseExt::json), this method
+    /// reads the entire response body into memory before attempting
+    /// deserialization. This is due to a Serde limitation since incremental
+    /// partial deserializing is not supported.
+    ///
     /// # Availability
     ///
     /// This method is only available when the [`json`](index.html#json) feature

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,0 +1,65 @@
+#![cfg(feature = "json")]
+
+use futures_lite::{future::block_on, io::AsyncRead};
+use isahc::prelude::*;
+use serde_json::Value;
+use std::{
+    io,
+    pin::Pin,
+    task::{Context, Poll},
+};
+use testserver::mock;
+
+#[macro_use]
+mod utils;
+
+#[test]
+fn deserialize_json() {
+    let m = mock! {
+        body: r#"{
+            "foo": "bar"
+        }"#,
+    };
+
+    let mut response = isahc::get(m.url()).unwrap();
+    let data = response.json::<Value>().unwrap();
+
+    assert_eq!(data["foo"], "bar");
+}
+
+#[test]
+fn deserialize_json_async() {
+    let m = mock! {
+        body: r#"{
+            "foo": "bar"
+        }"#,
+    };
+
+    block_on(async move {
+        let mut response = isahc::get_async(m.url()).await.unwrap();
+        let data = response.json::<Value>().await.unwrap();
+
+        assert_eq!(data["foo"], "bar");
+    });
+}
+
+#[test]
+fn deserialize_json_async_io_error() {
+    struct BadReader;
+
+    impl AsyncRead for BadReader {
+        fn poll_read(
+            self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            _buf: &mut [u8],
+        ) -> Poll<io::Result<usize>> {
+            Poll::Ready(Err(io::ErrorKind::UnexpectedEof.into()))
+        }
+    }
+
+    block_on(async move {
+        let mut response = http::Response::new(BadReader);
+
+        assert_matches!(response.json::<Value>().await, Err(e) if e.is_io());
+    });
+}


### PR DESCRIPTION
Add an async equivalent of `ReadResponseExt::json` for deserializing JSON responses asynchronously.

This allocates and stores the entire response in memory up front, but we have not much choice due to a serde limitation.

Fixes #245.