### PR TITLE
Add experimental rustls support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,13 @@ spnego = ["curl-sys/spnego"]
 static-curl = ["curl/static-curl"]
 static-ssl = ["curl/static-ssl"]
 text-decoding = ["encoding_rs", "mime"]
+tls-rustls = ["curl/rustls"]
 unstable-interceptors = []
 
 [dependencies]
 crossbeam-utils = "0.8"
-curl = "0.4.34"
-curl-sys = "0.4.37"
+curl = { git = "https://github.com/alexcrichton/curl-rust", branch = "rustls" }
+curl-sys = { git = "https://github.com/alexcrichton/curl-rust", branch = "rustls" }
 futures-lite = "1.11"
 http = "0.2.1"
 log = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ unstable-interceptors = []
 async-channel = "1.6"
 castaway = "0.1"
 crossbeam-utils = "0.8"
-curl = { git = "https://github.com/alexcrichton/curl-rust", branch = "rustls" }
-curl-sys = { git = "https://github.com/alexcrichton/curl-rust", branch = "rustls" }
+curl = { git = "https://github.com/alexcrichton/curl-rust", branch = "main" }
+curl-sys = { git = "https://github.com/alexcrichton/curl-rust", branch = "main" }
 event-listener = "2.5"
 futures-lite = "1.11"
 http = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,8 +35,8 @@ unstable-interceptors = []
 async-channel = "1.6"
 castaway = "0.1"
 crossbeam-utils = "0.8"
-curl = { git = "https://github.com/alexcrichton/curl-rust", branch = "main" }
-curl-sys = { git = "https://github.com/alexcrichton/curl-rust", branch = "main" }
+curl = "0.4.42"
+curl-sys = "0.4.52"
 event-listener = "2.5"
 futures-lite = "1.11"
 http = "0.2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ spnego = ["curl-sys/spnego"]
 static-curl = ["curl/static-curl"]
 static-ssl = ["curl/static-ssl"]
 text-decoding = ["encoding_rs", "mime"]
-tls-rustls = ["curl/rustls"]
+unstable-rustls-tls = ["curl/rustls"]
 unstable-interceptors = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ Not every library is perfect for every use-case. While Isahc strives to be a ful
 
 - **Tiny binaries**: If you are creating an application where tiny binary size is a key priority, you might find Isahc to be too large for you. While Isahc's dependencies are carefully curated and a number of features can be disabled, Isahc's core feature set includes things like async which does have some file size overhead. You might find something like [ureq] more suitable.
 - **WebAssembly support**: If your project needs to be able to be compiled to WebAssembly, then Isahc will probably not work for you. Instead you might like an HTTP client that supports multiple backends such as [Surf].
-- **Rustls support**: We hope to support [rustls] as a TLS backend someday, it is not currently supported directly. If for some reason rustls is a hard requirement for you, you'll need to use a different HTTP client for now.
 
 ## Sponsors
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 criterion = "0.3"
-curl = "0.4"
+curl = { git = "https://github.com/alexcrichton/curl-rust", branch = "rustls" }
 rayon = "1"
 rouille = "3"
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 criterion = "0.3"
-curl = { git = "https://github.com/alexcrichton/curl-rust", branch = "main" }
+curl = "0.4.42"
 rayon = "1"
 rouille = "3"
 

--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [dependencies]
 criterion = "0.3"
-curl = { git = "https://github.com/alexcrichton/curl-rust", branch = "rustls" }
+curl = { git = "https://github.com/alexcrichton/curl-rust", branch = "main" }
 rayon = "1"
 rouille = "3"
 

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -6,7 +6,7 @@ use isahc::prelude::*;
 fn main() -> Result<(), isahc::Error> {
     // Send a GET request and wait for the response headers.
     // Must be `mut` so we can read the response body.
-    let mut response = isahc::get("http://example.org")?;
+    let mut response = isahc::get("https://example.org")?;
 
     // Print some basic info about the response to standard output.
     println!("Status: {}", response.status());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -47,9 +47,8 @@
 //! ```
 //!
 //! If you want to customize the request by adding headers, setting timeouts,
-//! etc, then you can create a [`Request`][Request] using a
-//! builder-style fluent interface, then finishing it off with a
-//! [`send`][RequestExt::send]:
+//! etc, then you can create a [`Request`][Request] using a builder-style fluent
+//! interface, then finishing it off with a [`send`][RequestExt::send]:
 //!
 //! ```no_run
 //! use isahc::{prelude::*, Request};
@@ -201,6 +200,12 @@
 //! Enable the new interceptors API (replaces the old unstable middleware API).
 //! Unstable until the API is finalized. This an unstable feature whose
 //! interface may change between patch releases.
+//!
+//! ### `unstable-rustls-tls`
+//!
+//! Use [rustls](https://github.com/rustls/rustls) as the TLS backend for HTTPS
+//! requests. Currently unstable as the rustls backend in libcurl currently has
+//! some known issues and is not yet recommended for production use.
 //!
 //! # Logging and tracing
 //!


### PR DESCRIPTION
Add the ability to opt-in to using rustls as the TLS engine for HTTPS requests with a `unstable-rustls-tls` crate feature.

Based on upstream work in https://github.com/alexcrichton/curl-rust/pull/374.

See #199.