### PR TITLE
Allow setting low speed timeouts via Configurable

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -89,6 +89,16 @@ pub trait Configurable: request::WithRequestConfig {
         })
     }
 
+    /// Specify a maximum amount of time where transfer rate can go below
+    /// a minimum speed limit. `low_speed` is that limit in bytes/s.
+    ///
+    /// If not set, no low speed limits are imposed.
+    fn low_speed_timeout(self, low_speed: u32, timeout: Duration) -> Self {
+        self.with_config(move |config| {
+            config.low_speed_timeout = Some((low_speed, timeout));
+        })
+    }
+
     /// Configure how the use of HTTP versions should be negotiated with the
     /// server.
     ///

--- a/src/config/request.rs
+++ b/src/config/request.rs
@@ -65,6 +65,7 @@ define_request_config! {
     // Used by curl
     timeout: Option<Duration>,
     connect_timeout: Option<Duration>,
+    low_speed_timeout: Option<(u32, Duration)>,
     version_negotiation: Option<VersionNegotiation>,
     automatic_decompression: Option<bool>,
     authentication: Option<Authentication>,
@@ -96,6 +97,11 @@ impl SetOpt for RequestConfig {
     fn set_opt<H>(&self, easy: &mut Easy2<H>) -> Result<(), curl::Error> {
         if let Some(timeout) = self.timeout {
             easy.timeout(timeout)?;
+        }
+
+        if let Some((low_speed, timeout)) = self.low_speed_timeout {
+            easy.low_speed_limit(low_speed)?;
+            easy.low_speed_time(timeout)?;
         }
 
         if let Some(timeout) = self.connect_timeout {


### PR DESCRIPTION
 Expose libcurl's low speed timeout functionality by adding
 a `low_speed_timeout()` method to `Configurable`.