### PR TITLE
Handle raw UTF-8 bytes in redirect headers

### DIFF
--- a/src/agent/timer.rs
+++ b/src/agent/timer.rs
@@ -15,13 +15,16 @@ impl Timer {
     }
 
     pub(crate) fn is_expired(&self, now: Instant) -> bool {
-        self.timeout.load()
+        self.timeout
+            .load()
             .map(|timeout| now >= timeout)
             .unwrap_or(false)
     }
 
     pub(crate) fn get_remaining(&self, now: Instant) -> Option<Duration> {
-        self.timeout.load().map(|timeout| timeout.saturating_duration_since(now))
+        self.timeout
+            .load()
+            .map(|timeout| timeout.saturating_duration_since(now))
     }
 
     pub(crate) fn start(&self, timeout: Duration) {

--- a/src/cookies/psl/mod.rs
+++ b/src/cookies/psl/mod.rs
@@ -19,8 +19,7 @@
 //! list. If we can't, then we log a warning and use the stale list anyway,
 //! since a stale list is better than no list at all.
 
-use crate::request::RequestExt;
-use crate::ReadResponseExt;
+use crate::{request::RequestExt, ReadResponseExt};
 use chrono::{prelude::*, Duration};
 use once_cell::sync::Lazy;
 use parking_lot::{RwLock, RwLockUpgradableReadGuard};

--- a/src/error.rs
+++ b/src/error.rs
@@ -328,7 +328,10 @@ impl fmt::Debug for Error {
             .field("kind", &self.kind())
             .field("context", &self.0.context)
             .field("source", &self.source())
-            .field("source_type", &self.0.source.as_ref().map(|e| e.type_name()))
+            .field(
+                "source_type",
+                &self.0.source.as_ref().map(|e| e.type_name()),
+            )
             .finish()
     }
 }

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -6,7 +6,7 @@ use crate::{
     interceptor::{Context, Interceptor, InterceptorFuture},
     request::RequestExt,
 };
-use http::{HeaderValue, Request, Response, Uri, header::ToStrError};
+use http::{header::ToStrError, HeaderValue, Request, Response, Uri};
 use std::{borrow::Cow, convert::TryFrom, str};
 use url::Url;
 


### PR DESCRIPTION
Try to parse the `Location` header as UTF-8 bytes as a fallback if the header value is not valid US-ASCII. This is technically against the URI spec which requires all literal characters in the URI to be US-ASCII (see [RFC 3986, Section 4.1](https://tools.ietf.org/html/rfc3986#section-4.1)).

This is also more or less against the HTTP spec, which historically allowed for ISO-8859-1 text in header values but since was restricted to US-ASCII plus opaque bytes. Never has UTF-8 been encouraged or allowed as-such. See [RFC 7230, Section 3.2.4](https://tools.ietf.org/html/rfc7230#section-3.2.4) for more info.

However, some bad or misconfigured web servers will do this anyway, and most web browsers recover from this by allowing and interpreting UTF-8 characters as themselves even though they _should_ have been percent-encoded. The third-party URI parsers that we use have no such leniency, so we percent-encode such bytes (if legal UTF-8) ahead of time before handing them off to the URI parser.

This is in the spirit of being generous with what we accept (within reason) while being strict in what we produce. Since real websites exhibit this out-of-spec behavior it is worth handling it.

Note that the underlying `tiny_http` library that our HTTP test mocking is based on does not allow UTF-8 header values right now, so we can't really test this efficiently. We already have a couple tests out there doing some raw TCP munging for one reason or another, so in the future we need to make sure to rewrite `testserver` to allow such headers and then enable the test. For now I've manually verified that this works.

Fixes #315.