### PR TITLE
Replace flume with async-channel

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ text-decoding = ["encoding_rs", "mime"]
 unstable-interceptors = []
 
 [dependencies]
+async-channel = "1.6"
 crossbeam-utils = "0.8"
 curl = "0.4.34"
 curl-sys = "0.4.37"
@@ -51,11 +52,6 @@ optional = true
 [dependencies.encoding_rs]
 version = "0.8"
 optional = true
-
-[dependencies.flume]
-version = "0.10"
-default-features = false
-features = ["async"]
 
 [dependencies.mime]
 version = "0.3"


### PR DESCRIPTION
Flume changes its minimum Rust version too often and also recently added a dependency chain involving longer compile times than ideal. Async-channel is comparable to flume for our use-case, is stable, and has a smaller dependency tree.