### PR TITLE
Bump MSRV to 1.46.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: "1.41.1"
+          toolchain: "1.46.0"
           default: true
 
       - run: cargo test --features ${{ env.FEATURES }},spnego,unstable-interceptors

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _Formerly known as [chttp]._
 [![Crates.io](https://img.shields.io/crates/v/isahc.svg)](https://crates.io/crates/isahc)
 [![Documentation](https://docs.rs/isahc/badge.svg)][documentation]
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Minimum supported Rust version](https://img.shields.io/badge/rustc-1.41+-yellow.svg)](#minimum-supported-rust-version)
+[![Minimum supported Rust version](https://img.shields.io/badge/rustc-1.46+-yellow.svg)](#minimum-supported-rust-version)
 [![Crates.io downloads](https://img.shields.io/crates/d/isahc)](https://crates.io/crates/isahc)
 ![Maintenance](https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg)
 [![Build](https://github.com/sagebind/isahc/workflows/ci/badge.svg)](https://github.com/sagebind/isahc/actions)
@@ -75,7 +75,7 @@ isahc = "1.3"
 
 ### Minimum supported Rust version
 
-The minimum supported Rust version (or _MSRV_) for Isahc is **stable Rust 1.41 or greater**, meaning we only guarantee that Isahc will compile if you use a rustc version of at least 1.41. It might compile with older versions but that could change at any time.
+The minimum supported Rust version (or _MSRV_) for Isahc is **stable Rust 1.46 or greater**, meaning we only guarantee that Isahc will compile if you use a rustc version of at least 1.46. It might compile with older versions but that could change at any time.
 
 This version is explicitly tested in CI and may only be bumped in new minor versions. Any changes to the supported minimum version will be called out in the release notes.
 


### PR DESCRIPTION
We need to increase our MSRV to 1.46.0 because this is the [new minimum version required by `socket2`](https://github.com/rust-lang/socket2/tree/8716af6fbf921cf318b6adb3c13259050d96a13a#minimum-supported-rust-version-msrv), which also effectively bumps the minimum version required for the next version of the `curl` crate.