### PR TITLE
Expose connection info in errors

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -422,6 +422,7 @@ impl fmt::Debug for Error {
                 "source_type",
                 &self.0.source.as_ref().map(|e| e.type_name()),
             )
+            .field("local_addr", &self.0.local_addr.get())
             .field("remote_addr", &self.0.remote_addr.get())
             .finish()
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -380,7 +380,6 @@ impl Error {
         self.0.local_addr.get().cloned()
     }
 
-
     /// Get the remote socket address of the last-used connection involved in
     /// this error, if known.
     ///

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -210,6 +210,14 @@ impl RequestHandler {
 
     /// Set the final result for this transfer.
     pub(crate) fn set_result(&mut self, result: Result<(), Error>) {
+        let result = result.map_err(|e| {
+            if let Some(addr) = self.get_primary_addr() {
+                e.with_remote_addr(addr)
+            } else {
+                e
+            }
+        });
+
         if self.shared.result.set(result).is_err() {
             tracing::debug!("attempted to set error multiple times");
         }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -210,12 +210,16 @@ impl RequestHandler {
 
     /// Set the final result for this transfer.
     pub(crate) fn set_result(&mut self, result: Result<(), Error>) {
-        let result = result.map_err(|e| {
-            if let Some(addr) = self.get_primary_addr() {
-                e.with_remote_addr(addr)
-            } else {
-                e
+        let result = result.map_err(|mut e| {
+            if let Some(addr) = self.get_local_addr() {
+                e = e.with_local_addr(addr)
             }
+
+            if let Some(addr) = self.get_primary_addr() {
+                e = e.with_remote_addr(addr)
+            }
+
+            e
         });
 
         if self.shared.result.set(result).is_err() {

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -212,11 +212,11 @@ impl RequestHandler {
     pub(crate) fn set_result(&mut self, result: Result<(), Error>) {
         let result = result.map_err(|mut e| {
             if let Some(addr) = self.get_local_addr() {
-                e = e.with_local_addr(addr)
+                e = e.with_local_addr(addr);
             }
 
             if let Some(addr) = self.get_primary_addr() {
-                e = e.with_remote_addr(addr)
+                e = e.with_remote_addr(addr);
             }
 
             e

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -113,7 +113,10 @@ impl Interceptor for RedirectInterceptor {
                     // There's not really a good way of handling this gracefully, so
                     // we just return an error so that the user knows about it.
                     if !request_body.reset() {
-                        return Err(Error::with_response(ErrorKind::RequestBodyNotRewindable, &response));
+                        return Err(Error::with_response(
+                            ErrorKind::RequestBodyNotRewindable,
+                            &response,
+                        ));
                     }
 
                     // Update the request to point to the new URI.

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -77,7 +77,7 @@ impl Interceptor for RedirectInterceptor {
                 if let Some(location) = get_redirect_location(&effective_uri, &response) {
                     // If we've reached the limit, return an error as requested.
                     if redirect_count >= limit {
-                        return Err(ErrorKind::TooManyRedirects.into());
+                        return Err(Error::with_response(ErrorKind::TooManyRedirects, &response));
                     }
 
                     // Set referer header.
@@ -113,7 +113,7 @@ impl Interceptor for RedirectInterceptor {
                     // There's not really a good way of handling this gracefully, so
                     // we just return an error so that the user knows about it.
                     if !request_body.reset() {
-                        return Err(ErrorKind::RequestBodyNotRewindable.into());
+                        return Err(Error::with_response(ErrorKind::RequestBodyNotRewindable, &response));
                     }
 
                     // Update the request to point to the new URI.

--- a/src/response.rs
+++ b/src/response.rs
@@ -274,7 +274,7 @@ impl<R: Read> ReadResponseExt<R> for Response<R> {
 
     #[cfg(feature = "text-decoding")]
     fn text(&mut self) -> io::Result<String> {
-        crate::text::Decoder::for_response(&self).decode_reader(self.body_mut())
+        crate::text::Decoder::for_response(self).decode_reader(self.body_mut())
     }
 
     #[cfg(feature = "json")]
@@ -430,7 +430,7 @@ impl<R: AsyncRead + Unpin> AsyncReadResponseExt<R> for Response<R> {
 
     #[cfg(feature = "text-decoding")]
     fn text(&mut self) -> crate::text::TextFuture<'_, &mut R> {
-        crate::text::Decoder::for_response(&self).decode_reader_async(self.body_mut())
+        crate::text::Decoder::for_response(self).decode_reader_async(self.body_mut())
     }
 
     #[cfg(feature = "json")]

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -34,13 +34,29 @@ fn local_addr_returns_expected_address() {
 }
 
 #[test]
-fn remote_addr_returns_expected_address_expected_address() {
+fn remote_addr_returns_expected_address() {
     let m = mock!();
 
     let response = isahc::get(m.url()).unwrap();
 
     assert!(!m.requests().is_empty());
     assert_eq!(response.remote_addr(), Some(m.addr()));
+}
+
+#[test]
+fn remote_addr_returns_expected_address_on_error() {
+    let server = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
+    let addr = server.local_addr().unwrap();
+
+    thread::spawn(move || {
+        let (mut client, _) = server.accept().unwrap();
+        client.write_all(b"foobar").unwrap();
+        client.flush().unwrap();
+    });
+
+    let error = isahc::get(format!("http://localhost:{}", addr.port())).unwrap_err();
+
+    assert_eq!(error.remote_addr(), Some(addr));
 }
 
 #[test]

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -44,7 +44,7 @@ fn remote_addr_returns_expected_address() {
 }
 
 #[test]
-fn remote_addr_returns_expected_address_on_error() {
+fn local_and_remote_addr_returns_expected_addresses_on_error() {
     let server = TcpListener::bind((Ipv4Addr::LOCALHOST, 0)).unwrap();
     let addr = server.local_addr().unwrap();
 
@@ -57,6 +57,8 @@ fn remote_addr_returns_expected_address_on_error() {
     let error = isahc::get(format!("http://localhost:{}", addr.port())).unwrap_err();
 
     assert_eq!(error.remote_addr(), Some(addr));
+    assert_eq!(error.local_addr().unwrap().ip(), Ipv4Addr::LOCALHOST);
+    assert!(error.local_addr().unwrap().port() > 0);
 }
 
 #[test]

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -2,9 +2,6 @@ use isahc::{config::RedirectPolicy, prelude::*, Body, HttpClient, Request};
 use test_case::test_case;
 use testserver::mock;
 
-#[macro_use]
-mod utils;
-
 #[test]
 fn response_301_no_follow() {
     let m = mock! {
@@ -216,13 +213,15 @@ fn redirect_non_rewindable_body_returns_error() {
     // Create a streaming body of unknown size.
     let upload_stream = Body::from_reader(Body::from_bytes_static(b"hello world"));
 
-    let result = Request::post(m1.url())
+    let error = Request::post(m1.url())
         .redirect_policy(RedirectPolicy::Follow)
         .body(upload_stream)
         .unwrap()
-        .send();
+        .send()
+        .unwrap_err();
 
-    assert_matches!(result, Err(e) if e == isahc::error::ErrorKind::RequestBodyNotRewindable);
+    assert_eq!(error, isahc::error::ErrorKind::RequestBodyNotRewindable);
+    assert_eq!(error.remote_addr(), Some(m1.addr()));
     assert_eq!(m1.request().method, "POST");
 }
 
@@ -235,14 +234,16 @@ fn redirect_limit_is_respected() {
         }
     };
 
-    let result = Request::get(m.url())
+    let error = Request::get(m.url())
         .redirect_policy(RedirectPolicy::Limit(5))
         .body(())
         .unwrap()
-        .send();
+        .send()
+        .unwrap_err();
 
     // Request should error with too many redirects.
-    assert_matches!(result, Err(e) if e == isahc::error::ErrorKind::TooManyRedirects);
+    assert_eq!(error, isahc::error::ErrorKind::TooManyRedirects);
+    assert_eq!(error.remote_addr(), Some(m.addr()));
 
     // After request (limit + 1) that returns a redirect should error.
     assert_eq!(m.requests().len(), 6);


### PR DESCRIPTION
Add `local_addr` and `remote_addr` to `Error` which expose the local and remote network addresses of the last used connection for a request before the error occurred, if known.

Fixes #336.