### PR TITLE
Clear timer once it expires, else it is effectively repeating

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -532,6 +532,7 @@ impl AgentContext {
 
         // If curl gave us a timeout, check if it has expired.
         if self.timer.is_expired(now) {
+            self.timer.stop();
             self.multi.timeout().map_err(Error::from_any)?;
         }
 


### PR DESCRIPTION
After the timer "fires" once, we must clear it ourselves, curl does not clear it for us using the callback after calling `action`, only when it changes. After our curl-provided timeout has expired, fall back to our default timeout, or else we continue polling in a loop.

Closes #348