### PR TITLE
Replace chrono with httpdate internally

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,10 @@ status = "actively-developed"
 
 [features]
 default = ["http2", "static-curl", "text-decoding"]
-cookies = ["chrono"]
+cookies = ["httpdate"]
 http2 = ["curl/http2"]
 json = ["serde", "serde_json"]
-psl = ["parking_lot", "publicsuffix"]
+psl = ["httpdate", "parking_lot", "publicsuffix"]
 spnego = ["curl-sys/spnego"]
 static-curl = ["curl/static-curl"]
 static-ssl = ["curl/static-ssl"]
@@ -47,12 +47,12 @@ sluice = "0.5.4"
 url = "2.2"
 waker-fn = "1"
 
-[dependencies.chrono]
-version = "0.4"
-optional = true
-
 [dependencies.encoding_rs]
 version = "0.8"
+optional = true
+
+[dependencies.httpdate]
+version = "1"
 optional = true
 
 [dependencies.mime]

--- a/src/cookies/cookie.rs
+++ b/src/cookies/cookie.rs
@@ -1,5 +1,9 @@
-use chrono::{prelude::*, Duration};
-use std::{error::Error, fmt, str};
+use std::{
+    error::Error,
+    fmt,
+    str,
+    time::{Duration, SystemTime},
+};
 
 /// An error which can occur when attempting to parse a cookie string.
 #[derive(Debug)]
@@ -46,7 +50,7 @@ pub struct CookieBuilder {
 
     /// Time when this cookie expires. If not present, then this is a session
     /// cookie that expires when the current client session ends.
-    expiration: Option<DateTime<Utc>>,
+    expiration: Option<SystemTime>,
 }
 
 impl CookieBuilder {
@@ -93,8 +97,11 @@ impl CookieBuilder {
 
     /// Time when this cookie expires. If not present, then this is a session
     /// cookie that expires when the current client session ends.
-    pub fn expiration(mut self, expiration: DateTime<Utc>) -> Self {
-        self.expiration = Some(expiration);
+    pub fn expiration<T>(mut self, expiration: T) -> Self
+    where
+        T: Into<SystemTime>,
+    {
+        self.expiration = Some(expiration.into());
         self
     }
 
@@ -160,7 +167,7 @@ pub struct Cookie {
 
     /// Time when this cookie expires. If not present, then this is a session
     /// cookie that expires when the current client session ends.
-    expiration: Option<DateTime<Utc>>,
+    expiration: Option<SystemTime>,
 }
 
 impl Cookie {
@@ -260,9 +267,10 @@ impl Cookie {
 
     /// Check if the cookie has expired.
     pub(crate) fn is_expired(&self) -> bool {
-        match self.expiration {
-            Some(time) => time < Utc::now(),
-            None => false,
+        if let Some(time) = self.expiration.as_ref() {
+            *time < SystemTime::now()
+        } else {
+            false
         }
     }
 
@@ -289,8 +297,8 @@ impl Cookie {
                 if name.eq_ignore_ascii_case(b"Expires") {
                     if cookie_expiration.is_none() {
                         if let Ok(value) = str::from_utf8(value) {
-                            if let Ok(time) = DateTime::parse_from_rfc2822(value) {
-                                cookie_expiration = Some(time.with_timezone(&Utc));
+                            if let Ok(time) = httpdate::parse_http_date(value) {
+                                cookie_expiration = Some(time);
                             }
                         }
                     }
@@ -301,7 +309,8 @@ impl Cookie {
                 } else if name.eq_ignore_ascii_case(b"Max-Age") {
                     if let Ok(value) = str::from_utf8(value) {
                         if let Ok(seconds) = value.parse() {
-                            cookie_expiration = Some(Utc::now() + Duration::seconds(seconds));
+                            cookie_expiration =
+                                Some(SystemTime::now() + Duration::from_secs(seconds));
                         }
                     }
                 } else if name.eq_ignore_ascii_case(b"Path") {
@@ -416,6 +425,12 @@ mod tests {
     use super::*;
     use test_case::test_case;
 
+    fn system_time_timestamp(time: &SystemTime) -> u64 {
+        time.duration_since(SystemTime::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+    }
+
     #[test_case("foo")]
     #[test_case("foo;=bar")]
     #[test_case("bad_name@?=bar")]
@@ -449,7 +464,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_set_cookie_header() {
+    fn parse_set_cookie_header_expires() {
         let cookie = Cookie::parse(
             "foo=bar; path=/sub;Secure; DOMAIN=baz.com;expires=Wed, 21 Oct 2015 07:28:00 GMT",
         )
@@ -460,15 +475,37 @@ mod tests {
         assert_eq!(cookie.path(), Some("/sub"));
         assert_eq!(cookie.domain.as_deref(), Some("baz.com"));
         assert!(cookie.is_secure());
+        assert!(!cookie.is_expired());
         assert_eq!(
-            cookie.expiration.as_ref().map(|t| t.timestamp()),
+            cookie.expiration.as_ref().map(system_time_timestamp),
             Some(1_445_412_480)
         );
     }
 
     #[test]
+    fn parse_set_cookie_header_max_age() {
+        let cookie =
+            Cookie::parse("foo=bar; path=/sub;Secure; DOMAIN=baz.com; max-age=60").unwrap();
+
+        assert_eq!(cookie.name(), "foo");
+        assert_eq!(cookie.value(), "bar");
+        assert_eq!(cookie.path(), Some("/sub"));
+        assert_eq!(cookie.domain.as_deref(), Some("baz.com"));
+        assert!(cookie.is_secure());
+        assert!(!cookie.is_expired());
+        assert!(
+            cookie
+                .expiration
+                .unwrap()
+                .duration_since(SystemTime::now())
+                .unwrap()
+                <= Duration::from_secs(60)
+        );
+    }
+
+    #[test]
     fn create_cookie() {
-        let exp = Utc::now();
+        let exp = SystemTime::now();
 
         let cookie = Cookie::builder("foo", "bar")
             .domain("baz.com")

--- a/src/cookies/cookie.rs
+++ b/src/cookies/cookie.rs
@@ -20,14 +20,14 @@ impl Error for ParseError {}
 /// Builder for a [`Cookie`].
 ///
 /// ```rust
-/// use chrono::{Utc, Duration};
 /// use isahc::cookies::Cookie;
+/// use std::time::{Duration, SystemTime};
 ///
 /// let cookie: Cookie = Cookie::builder("name", "value") // or CookieBuilder::new("name", "value")
 ///     .domain("example.com")
 ///     .path("/")
 ///     .secure(true)
-///     .expiration(Utc::now() + Duration::minutes(30))
+///     .expiration(SystemTime::now() + Duration::from_secs(30 * 60))
 ///     .build()
 ///     .unwrap();
 /// ```
@@ -475,7 +475,7 @@ mod tests {
         assert_eq!(cookie.path(), Some("/sub"));
         assert_eq!(cookie.domain.as_deref(), Some("baz.com"));
         assert!(cookie.is_secure());
-        assert!(!cookie.is_expired());
+        assert!(cookie.is_expired());
         assert_eq!(
             cookie.expiration.as_ref().map(system_time_timestamp),
             Some(1_445_412_480)


### PR DESCRIPTION
Remove chrono as a dependency to avoid any connection to the transitive [CVE-2020-26235 in `time` 0.2](https://github.com/rustsec/advisory-db/blob/9e93a3df4a54e70f2539a2ecdc3d70beef64c856/crates/time/RUSTSEC-2020-0071.md). This also requires removing chrono from the public API of `CookieBuilder` (added in https://github.com/sagebind/isahc/pull/349), which is probably for the best anyway before it is released so that we aren't tied to it. Expose `SystemTime` types instead, which both chrono and `time` are compatible with, should the consumer of the API choose to use either of those crates.

Replace formatting and parsing of HTTP date formats with the aptly-named    `httpdate` crate, which implements exactly those two operations and no more. As a side benefit this reduces our total transitive dependency count by 3 when the `cookies` feature is enabled.

This has been the only thing holding back a 1.6.0 release with #349 in it, since CVE-2020-26235 was brought to wider attention shortly after its merge and I've been thinking on how to best address that concern before the API is released and can't be changed without a BC break.