### PR TITLE
Add minimal versions test to CI

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -3,5 +3,6 @@ coverage:
     project:
       default:
         threshold: 1%
+    patch: false
 ignore:
   - "testserver/**/*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       # specifies its dependency as "^0.2".
       - name: Override openssl-sys version
         run: |
-          echo '[dependencies.openssl-sys]\nversion = "0.9.45"' >> Cargo.toml
+          echo "[dependencies.openssl-sys]\nversion = \"0.9.45\"" >> Cargo.toml
 
       - name: Update Cargo.lock
         run: cargo -Z minimal-versions update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,40 @@ jobs:
       - name: Run example program
         run: cargo run --release --example simple
 
+  test-minimal-versions:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          components: clippy
+          default: true
+
+      - name: Update Cargo.lock
+        run: cargo -Z minimal-versions update
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: cargo-${{ runner.os }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-
+
+      - name: Run tests
+        run: cargo test --features ${{ env.FEATURES }}
+
   analyze:
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       # specifies its dependency as "^0.2".
       - name: Override openssl-sys version
         run: |
-          echo "[dependencies.openssl-sys]\nversion = \"0.9.45\"" >> Cargo.toml
+          printf '[dependencies.openssl-sys]\nversion = "0.9.45"\n' >> Cargo.toml
 
       - name: Update Cargo.lock
         run: cargo -Z minimal-versions update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,11 +78,8 @@ jobs:
       # openssl-sys <0.9.45 relies on a feature in rustc_version >=0.2.2, but
       # specifies its dependency as "^0.2".
       - name: Override openssl-sys version
-        uses: ciiiii/toml-editor@1.0.0
-        with:
-          file: Cargo.toml
-          key: "dependencies.openssl-sys.version"
-          value: "0.9.45"
+        run: |
+          echo '[dependencies.openssl-sys]\nversion = "0.9.45"' >> Cargo.toml
 
       - name: Update Cargo.lock
         run: cargo -Z minimal-versions update

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,15 @@ jobs:
           components: clippy
           default: true
 
+      # openssl-sys <0.9.45 relies on a feature in rustc_version >=0.2.2, but
+      # specifies its dependency as "^0.2".
+      - name: Override openssl-sys version
+        uses: ciiiii/toml-editor@1.0.0
+        with:
+          file: Cargo.toml
+          key: "dependencies.openssl-sys.version"
+          value: "0.9.45"
+
       - name: Update Cargo.lock
         run: cargo -Z minimal-versions update
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,8 +34,8 @@ unstable-interceptors = []
 
 [dependencies]
 async-channel = "1.6"
-castaway = "0.1"
-crossbeam-utils = "0.8"
+castaway = "0.1.1"
+crossbeam-utils = ">=0.7.0, <0.9.0"
 curl = "0.4.42"
 curl-sys = "0.4.52"
 event-listener = "2.5"
@@ -89,7 +89,7 @@ features = ["std", "std-future"]
 
 [dev-dependencies]
 env_logger = "0.9"
-flate2 = "1.0"
+flate2 = "1.0.3"
 indicatif = "0.15"
 rayon = "1"
 static_assertions = "1.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,20 +33,20 @@ unstable-rustls-tls = ["curl/rustls"]
 unstable-interceptors = []
 
 [dependencies]
-async-channel = "1.6"
+async-channel = "1.4.2"
 castaway = "0.1.1"
 crossbeam-utils = ">=0.7.0, <0.9.0"
 curl = "0.4.42"
 curl-sys = "0.4.52"
-event-listener = "2.5"
-futures-lite = "1.11"
+event-listener = "2.3.3"
+futures-lite = "1.10.1"
 http = "0.2.1"
 log = "0.4"
 once_cell = "1"
-polling = "2.0"
+polling = "2"
 slab = "0.4"
 sluice = "0.5.4"
-url = "2.2"
+url = "2.1"
 waker-fn = "1"
 
 [dependencies.encoding_rs]
@@ -62,7 +62,7 @@ version = "0.3"
 optional = true
 
 [dependencies.parking_lot]
-version = "0.11"
+version = ">=0.9.0, <0.12.0"
 optional = true
 
 [dependencies.publicsuffix]

--- a/src/text.rs
+++ b/src/text.rs
@@ -63,7 +63,7 @@ impl Decoder {
         {
             if let Some(charset) = content_type.get_param(mime::CHARSET) {
                 if let Some(encoding) =
-                    encoding_rs::Encoding::for_label(charset.as_str().as_bytes())
+                    encoding_rs::Encoding::for_label(charset.as_ref().as_bytes())
                 {
                     return Self::new(encoding);
                 } else {

--- a/tests/encoding.rs
+++ b/tests/encoding.rs
@@ -66,7 +66,7 @@ fn request_gzip_without_automatic_decompression() {
     m.request().expect_header("Accept-Encoding", "gzip");
 
     // Response body size should be known.
-    assert_eq!(response.body().len(), Some(31));
+    assert_eq!(response.body().len(), Some(body_encoded.len() as u64));
 }
 
 #[test]


### PR DESCRIPTION
Add step to CI that compiles and runs all tests against the lowest compatible versions of all crates to ensure that the specified dependency ranges are actually compatible.

See also <https://users.rust-lang.org/t/psa-please-specify-precise-dependency-versions-in-cargo-toml/71277>.