### PR TITLE
Auto-referer header fixes

### DIFF
--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -260,7 +260,7 @@ fn create_referer(uri: &Uri, target_uri: &Uri) -> Option<HeaderValue> {
         referer.push_str(authority.host());
 
         if let Some(port) = authority.port() {
-            referer.push_str(":");
+            referer.push(':');
             referer.push_str(port.as_str());
         }
     }
@@ -268,7 +268,7 @@ fn create_referer(uri: &Uri, target_uri: &Uri) -> Option<HeaderValue> {
     referer.push_str(uri.path());
 
     if let Some(query) = uri.query() {
-        referer.push_str("?");
+        referer.push('?');
         referer.push_str(query);
     }
 

--- a/src/redirect.rs
+++ b/src/redirect.rs
@@ -8,7 +8,7 @@ use crate::{
     request::RequestExt,
 };
 use http::{header::ToStrError, uri::Scheme, HeaderMap, HeaderValue, Request, Response, Uri};
-use std::{borrow::Cow, convert::TryFrom, str};
+use std::{borrow::Cow, convert::TryFrom, fmt::Write, str};
 use url::Url;
 
 /// How many redirects to follow by default if a limit is not specified. We
@@ -210,7 +210,7 @@ fn parse_location(location: &HeaderValue) -> Result<Cow<'_, str>, ToStrError> {
                     if byte.is_ascii() {
                         s.push(byte as char);
                     } else {
-                        s.push_str(&format!("%{:02x}", byte));
+                        write!(&mut s, "%{:02x}", byte).unwrap();
                     }
                 }
 

--- a/tests/redirects.rs
+++ b/tests/redirects.rs
@@ -264,7 +264,7 @@ fn auto_referer_sets_expected_header() {
     };
 
     let m1 = {
-        let location = m2.url();
+        let location = format!("{}#foo", m2.url());
         mock! {
             status: 301,
             headers {
@@ -281,8 +281,9 @@ fn auto_referer_sets_expected_header() {
         .send()
         .unwrap();
 
-    m2.request().expect_header("Referer", m1.url());
-    m3.request().expect_header("Referer", m2.url());
+    assert_eq!(m1.request().get_header("Referer").count(), 0);
+    assert_eq!(m2.request().get_header("Referer").collect::<Vec<_>>(), vec![m1.url()]);
+    assert_eq!(m3.request().get_header("Referer").collect::<Vec<_>>(), vec![m2.url()]);
 }
 
 #[test]


### PR DESCRIPTION
Fix various aspects of the `auto_referer` option:

- Fix multiple `Referer` headers being included when two or more redirects are followed in a request
- URL fragments and userinfo parts of the authority should not be included in the `Referer` header
- Don't include a `Referer` header when redirecting from an HTTPS URL to an HTTP URL, as per [RFC 7231](https://httpwg.org/specs/rfc7231.html#header.referer) recommendation
- Scrub sensitive headers when redirecting to a different authority

Fixes #392