### PR TITLE
Upgrade curl-sys to 0.4.55

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ version = "0.4.43"
 default-features = false
 
 [dependencies.curl-sys]
-version = "0.4.54"
+version = "0.4.55"
 default-features = false
 
 [dependencies.data-encoding]


### PR DESCRIPTION
This updates the bundled curl version to 7.83.1, which fixes several new CVEs.