### PR TITLE
feat(benches): Add bench with reqwest blocking

### DIFF
--- a/benchmarks/Cargo.toml
+++ b/benchmarks/Cargo.toml
@@ -9,6 +9,7 @@ criterion = "0.3"
 curl = "0.4.42"
 rayon = "1"
 rouille = "3"
+reqwest = { version = "0.11.10", features = ["blocking"] }
 
 [dependencies.isahc]
 path = ".."

--- a/benchmarks/benches/download.rs
+++ b/benchmarks/benches/download.rs
@@ -49,7 +49,7 @@ fn benchmark(c: &mut Criterion) {
         )
     });
 
-    c.bench_function("download 64K: hyper", move |b| {
+    c.bench_function("download 64K: reqwest", move |b| {
         use reqwest::blocking::Client;
 
         let server = TestServer::static_response(&DATA);

--- a/benchmarks/benches/download.rs
+++ b/benchmarks/benches/download.rs
@@ -48,6 +48,22 @@ fn benchmark(c: &mut Criterion) {
             BatchSize::SmallInput,
         )
     });
+
+    c.bench_function("download 64K: hyper", move |b| {
+        use reqwest::blocking::Client;
+
+        let server = TestServer::static_response(&DATA);
+        let endpoint = server.endpoint();
+
+        b.iter_batched(
+            Client::new,
+            |client| {
+                let req = client.get(&endpoint).build().unwrap();
+                let _ = client.execute(req).unwrap().copy_to(&mut sink()).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
 }
 
 criterion_group!(benches, benchmark);


### PR DESCRIPTION
Signed-off-by: Xuanwo <github@xuanwo.io>

---

This PR will add `reqwest` (with the `blocking` feature enabled) to benchmarks so that we can measure the perf with reqwest(hyper).