### PR TITLE
Add note about cookie domain prefix in docs

### DIFF
--- a/src/cookies/cookie.rs
+++ b/src/cookies/cookie.rs
@@ -75,8 +75,8 @@ impl CookieBuilder {
     /// Sets the domain the cookie belongs to.
     ///
     /// Note that the domain will be preserved exactly as supplied. If the
-    /// string has a `.` prefix that should be ignored, then you must remove it
-    /// manually first.
+    /// string has a `.` prefix that should be ignored (such as allowed by the
+    /// `Set-Cookie` HTTP header), then you must remove it manually first.
     pub fn domain<S>(mut self, domain: S) -> Self
     where
         S: Into<String>,

--- a/src/cookies/cookie.rs
+++ b/src/cookies/cookie.rs
@@ -73,6 +73,10 @@ impl CookieBuilder {
     }
 
     /// Sets the domain the cookie belongs to.
+    ///
+    /// Note that the domain will be preserved exactly as supplied. If the
+    /// string has a `.` prefix that should be ignored, then you must remove it
+    /// manually first.
     pub fn domain<S>(mut self, domain: S) -> Self
     where
         S: Into<String>,


### PR DESCRIPTION
Clarify that `CookieBuilder::domain` does not handle any prefixes specific to the parsing of the `Set-Cookie` header in the function documentation.

See #387.