### PR TITLE
Remove parking lot dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ http2 = ["curl/http2"]
 json = ["serde", "serde_json"]
 native-tls = ["curl/ssl", "curl-sys/ssl"]
 nightly = []
-psl = ["httpdate", "parking_lot", "publicsuffix"]
+psl = ["httpdate", "publicsuffix"]
 rustls-tls = ["rustls-ffi", "curl/rustls", "curl/static-curl"]
 rustls-tls-native-certs = ["rustls-tls", "data-encoding", "rustls-native-certs"]
 spnego = ["curl-sys/spnego"]
@@ -71,10 +71,6 @@ optional = true
 
 [dependencies.mime]
 version = "0.3"
-optional = true
-
-[dependencies.parking_lot]
-version = ">=0.9.0, <0.12.0"
 optional = true
 
 [dependencies.publicsuffix]

--- a/src/cookies/psl/mod.rs
+++ b/src/cookies/psl/mod.rs
@@ -21,15 +21,19 @@
 
 use crate::{request::RequestExt, ReadResponseExt};
 use once_cell::sync::Lazy;
-use parking_lot::{RwLock, RwLockUpgradableReadGuard};
 use publicsuffix::{List, Psl};
 use std::{
     error::Error,
+    sync::{
+        atomic::{AtomicBool, Ordering},
+        RwLock,
+    },
+    thread,
     time::{Duration, SystemTime},
 };
 
 /// How long should we use a cached list before refreshing?
-static TTL: Lazy<Duration> = Lazy::new(|| Duration::from_secs(24 * 60 * 60));
+static TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Global in-memory PSL cache.
 static CACHE: Lazy<RwLock<ListCache>> = Lazy::new(Default::default);
@@ -62,10 +66,22 @@ impl Default for ListCache {
 }
 
 impl ListCache {
+    // Check if the given domain is a public suffix.
+    fn is_public_suffix(&self, domain: &str) -> bool {
+        let domain = domain.as_bytes();
+
+        self.list
+            .suffix(domain)
+            // We don't want to block unknown hosts like `localhost`
+            .filter(publicsuffix::Suffix::is_known)
+            .filter(|suffix| suffix == &domain)
+            .is_some()
+    }
+
     fn needs_refreshed(&self) -> bool {
         match self.last_refreshed {
             Some(last_refreshed) => match last_refreshed.elapsed() {
-                Ok(elapsed) => elapsed > *TTL,
+                Ok(elapsed) => elapsed > TTL,
                 Err(_) => false,
             },
             None => true,
@@ -118,40 +134,35 @@ impl ListCache {
 /// If the current list information is stale, a background refresh will be
 /// triggered. The current data will be used to respond to this query.
 pub(crate) fn is_public_suffix(domain: impl AsRef<str>) -> bool {
-    let domain = domain.as_ref().as_bytes();
+    let domain = domain.as_ref();
+    let cache = CACHE.read().unwrap();
 
-    with_cache(|cache| {
-        // Check if the given domain is a public suffix.
-        cache
-            .list
-            .suffix(domain)
-            // We don't want to block unknown hosts like `localhost`
-            .filter(publicsuffix::Suffix::is_known)
-            .filter(|suffix| suffix == &domain)
-            .is_some()
-    })
+    // Check if the list needs to be refreshed.
+    if cache.needs_refreshed() {
+        refresh_in_background();
+    }
+
+    cache.is_public_suffix(domain)
 }
 
-/// Execute a given closure with a reference to the list cache. If the list is
-/// out of date, attempt to refresh it first before continuing.
-fn with_cache<T>(f: impl FnOnce(&ListCache) -> T) -> T {
-    let cache = CACHE.upgradable_read();
+fn refresh_in_background() {
+    static IS_REFRESHING: AtomicBool = AtomicBool::new(false);
 
-    // First check if the list needs to be refreshed.
-    if cache.needs_refreshed() {
-        // Upgrade our lock to gain write access.
-        let mut cache = RwLockUpgradableReadGuard::upgrade(cache);
+    // Only spawn a refresh thread if one isn't already running.
+    if IS_REFRESHING
+        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
+        .is_ok()
+    {
+        thread::spawn(|| {
+            let mut cache = CACHE.write().unwrap();
 
-        // If there was contention then the cache might not need refreshed any
-        // more.
-        if cache.needs_refreshed() {
-            if let Err(e) = cache.refresh() {
-                tracing::warn!("could not refresh public suffix list: {}", e);
+            if cache.needs_refreshed() {
+                if let Err(e) = cache.refresh() {
+                    tracing::warn!("could not refresh public suffix list: {}", e);
+                }
             }
-        }
 
-        f(&cache)
-    } else {
-        f(&cache)
+            IS_REFRESHING.store(false, Ordering::SeqCst);
+        });
     }
 }


### PR DESCRIPTION
Remove need for upgradeable read-write lock from parking lot in PSL cache by refreshing the list asynchronously in a background thread. This doesn't make much performance difference unless we decide to swap the cache atomically, but allows us to remove a dependency only used in one small location.