### PR TITLE
More dependency pruning with comments

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ json = ["serde", "serde_json"]
 native-tls = ["curl/ssl", "curl-sys/ssl"]
 nightly = []
 psl = ["httpdate", "publicsuffix"]
-rustls-tls = ["rustls-ffi", "curl/rustls", "curl/static-curl"]
+rustls-tls = ["curl/rustls", "curl/static-curl"]
 rustls-tls-native-certs = ["rustls-tls", "data-encoding", "rustls-native-certs"]
 spnego = ["curl-sys/spnego"]
 static-curl = ["curl/static-curl"]
@@ -35,69 +35,77 @@ text-decoding = ["encoding_rs", "mime"]
 unstable-interceptors = []
 
 [dependencies]
-async-channel = "1.4.2"
-castaway = "0.2"
-crossbeam-utils = ">=0.7.0, <0.9.0"
-event-listener = "2.3.3"
-futures-lite = "1.10.1"
-http = "0.2.1"
-log = "0.4"
-once_cell = "1"
-polling = "2"
-slab = "0.4"
-sluice = "0.5.4"
-url = "2.1"
-waker-fn = "1"
+async-channel = "1.4.2" # channel used for internal communication
+castaway = "0.2" # buffer type specialization
+crossbeam-utils = ">=0.7.0, <0.9.0" # synchronization primitives
+event-listener = "2.3.3" # synchronization primitive
+futures-lite = "1.10.1" # futures-io compatibility plus other helpers
+http = "0.2.1" # http ecosystem compatibility, part of API
+log = "0.4" # log ecosystem compatibility
+once_cell = "1" # used for a few singletons
+polling = "2" # async I/O driver
+sluice = "0.5.4" # byte buffers between curl and Isahc
+url = "2.1" # URL parsing
+waker-fn = "1" # async primitive
 
+# underlying HTTP engine that powers Isahc
 [dependencies.curl]
 version = "0.4.43"
 default-features = false
 
+# access to certain curl APIs not exposed in safe wrapper
 [dependencies.curl-sys]
 version = "0.4.55"
 default-features = false
 
+# used in TLS cert parsing
 [dependencies.data-encoding]
 version = "2"
 optional = true
 
+# used for proper locale-sensitive text decoding
 [dependencies.encoding_rs]
 version = "0.8"
 optional = true
 
+# used in cookie parsing
 [dependencies.httpdate]
 version = "1"
 optional = true
 
+# used to parse content-type header
 [dependencies.mime]
 version = "0.3"
 optional = true
 
+# PSL database parsing
 [dependencies.publicsuffix]
 version = "2.0.6"
 features = ["std"]
 optional = true
 
-[dependencies.rustls-ffi]
-version = "0.8"
-optional = true
-
+# access to native cert store when using rustls
 [dependencies.rustls-native-certs]
 version = "0.6"
 optional = true
 
+# serde ecosystem compatibility for serializing and deserializing requests and
+# responses
 [dependencies.serde]
 version = "1.0"
 optional = true
 
+# conveniences for sending and receiving JSON data
 [dependencies.serde_json]
 version = "1.0"
 optional = true
 
+# tracing ecosystem compatibility
 [dependencies.tracing]
 version = "0.1.17"
 features = ["log"]
 
+# tracing ecosystem compatibility
 [dependencies.tracing-futures]
 version = "0.2"
 default-features = false

--- a/src/agent/hasher.rs
+++ b/src/agent/hasher.rs
@@ -1,0 +1,32 @@
+use std::hash::{BuildHasherDefault, Hasher};
+
+pub(super) type BuildIntHasher = BuildHasherDefault<IntHasher>;
+
+/// Trivial hash function to use for our maps and sets that use simple integer
+/// types or file descriptors as keys.
+#[derive(Default)]
+pub(super) struct IntHasher([u8; 8], #[cfg(debug_assertions)] bool);
+
+impl Hasher for IntHasher {
+    fn write(&mut self, bytes: &[u8]) {
+        #[cfg(debug_assertions)]
+        {
+            if self.1 {
+                panic!("socket hash function can only be written to once");
+            } else {
+                self.1 = true;
+            }
+
+            if bytes.len() > 8 {
+                panic!("only a maximum of 8 bytes can be hashed");
+            }
+        }
+
+        (self.0[..bytes.len()]).copy_from_slice(bytes);
+    }
+
+    #[inline]
+    fn finish(&self) -> u64 {
+        u64::from_ne_bytes(self.0)
+    }
+}

--- a/src/agent/hasher.rs
+++ b/src/agent/hasher.rs
@@ -12,7 +12,7 @@ impl Hasher for IntHasher {
         #[cfg(debug_assertions)]
         {
             if self.1 {
-                panic!("socket hash function can only be written to once");
+                panic!("hash function can only be written to once");
             } else {
                 self.1 = true;
             }

--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -14,11 +14,12 @@ use crossbeam_utils::{atomic::AtomicCell, sync::WaitGroup};
 use curl::multi::{Events, Multi, Socket, SocketEvents};
 use futures_lite::future::block_on;
 use std::{
+    collections::HashMap,
     io,
     sync::{Arc, Mutex},
     task::Waker,
     thread,
-    time::{Duration, Instant}, collections::HashMap,
+    time::{Duration, Instant},
 };
 
 use self::{selector::Selector, timer::Timer};

--- a/src/agent/selector.rs
+++ b/src/agent/selector.rs
@@ -2,12 +2,12 @@ use curl::multi::Socket;
 use polling::{Event, Poller};
 use std::{
     collections::{HashMap, HashSet},
-    hash::{BuildHasherDefault, Hasher},
     io,
     sync::Arc,
     task::Waker,
     time::Duration,
 };
+use super::hasher::BuildIntHasher;
 
 /// Asynchronous I/O selector for sockets. Used by the agent to wait for network
 /// activity asynchronously, as directed by curl.
@@ -22,11 +22,11 @@ pub(crate) struct Selector {
     poller: Arc<Poller>,
 
     /// All of the sockets that we have been asked to keep track of.
-    sockets: HashMap<Socket, Registration, BuildHasherDefault<IntHasher>>,
+    sockets: HashMap<Socket, Registration, BuildIntHasher>,
 
     /// If a socket is currently invalid when it is registered, we put it in this
     /// set and try to register it again later.
-    bad_sockets: HashSet<Socket, BuildHasherDefault<IntHasher>>,
+    bad_sockets: HashSet<Socket, BuildIntHasher>,
 
     /// Socket events that have occurred. We re-use this vec every call for
     /// efficiency.
@@ -282,34 +282,5 @@ fn is_bad_socket_error(error: &io::Error) -> bool {
 
             _ => false,
         },
-    }
-}
-
-/// Trivial hash function to use for our maps and sets that use file descriptors
-/// as keys.
-#[derive(Default)]
-struct IntHasher([u8; 8], #[cfg(debug_assertions)] bool);
-
-impl Hasher for IntHasher {
-    fn write(&mut self, bytes: &[u8]) {
-        #[cfg(debug_assertions)]
-        {
-            if self.1 {
-                panic!("socket hash function can only be written to once");
-            } else {
-                self.1 = true;
-            }
-
-            if bytes.len() > 8 {
-                panic!("only a maximum of 8 bytes can be hashed");
-            }
-        }
-
-        (self.0[..bytes.len()]).copy_from_slice(bytes);
-    }
-
-    #[inline]
-    fn finish(&self) -> u64 {
-        u64::from_ne_bytes(self.0)
     }
 }

--- a/src/client.rs
+++ b/src/client.rs
@@ -1050,9 +1050,7 @@ impl HttpClient {
         let body = std::mem::take(request.body_mut());
         let has_body = !body.is_empty();
         let body_length = body.len();
-        let (handler, future) = RequestHandler::new(body);
-
-        let mut easy = curl::easy::Easy2::new(handler);
+        let (mut easy, future) = RequestHandler::new(body);
 
         // Set whether curl should generate verbose debug data for us to log.
         easy.verbose(easy.get_ref().is_debug_enabled())?;

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -167,7 +167,7 @@ impl RequestHandler {
         let mut easy = Easy2::new(handler);
         easy.get_mut().handle = easy.raw();
         let id = easy.get_ref().id();
-        easy.get_mut().span.record("id", &id);
+        easy.get_mut().span.record("id", id);
 
         (easy, future)
     }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -167,7 +167,7 @@ impl RequestHandler {
         let mut easy = Easy2::new(handler);
         easy.get_mut().handle = easy.raw();
         let id = easy.get_ref().id();
-        easy.get_mut().span.record("id", id);
+        easy.get_mut().span.record("id", &id);
 
         (easy, future)
     }


### PR DESCRIPTION
Remove the following dependencies:

- `rustls-ffi`: We don't actually need this directly, as curl pulls it in transitively as needed. Listing this as a direct dependency was unnecessary.
- `slab`: Performance testing yields no significant memory or performance improvements over just using a `HashMap` for our purposes, so replace the one occurrence of slab in the agent with a `HashMap` using a unique ID derived from the curl easy handle to keep track of requests.

Also add comments to `Cargo.toml` next to each runtime dependency which explains how the dependency is used and why it is there.