### PR TITLE
Remove several features from futures-lite

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ async-channel = "1.4.2" # channel used for internal communication
 castaway = "0.2" # buffer type specialization
 crossbeam-utils = ">=0.7.0, <0.9.0" # synchronization primitives
 event-listener = "2.3.3" # synchronization primitive
-futures-lite = "1.10.1" # futures-io compatibility plus other helpers
+futures-io = "0.3.24" # futures-io ecosystem compatibility
 http = "0.2.1" # http ecosystem compatibility, part of API
 log = "0.4" # log ecosystem compatibility
 once_cell = "1" # used for a few singletons
@@ -67,6 +67,11 @@ optional = true
 [dependencies.encoding_rs]
 version = "0.8"
 optional = true
+
+# common futures primitives
+[dependencies.futures-lite]
+version = "1.10.1"
+default-features = false
 
 # used in cookie parsing
 [dependencies.httpdate]
@@ -113,6 +118,7 @@ features = ["std", "std-future"]
 
 [dev-dependencies]
 env_logger = "0.9"
+futures-lite = "1.10.1"
 flate2 = "1.0.3"
 indicatif = "0.15"
 rayon = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ text-decoding = ["encoding_rs", "mime"]
 unstable-interceptors = []
 
 [dependencies]
-async-channel = "1.4.2" # channel used for internal communication
+async-channel = "1.7" # channel used for internal communication
 castaway = "0.2" # buffer type specialization
 crossbeam-utils = ">=0.7.0, <0.9.0" # synchronization primitives
 event-listener = "2.3.3" # synchronization primitive

--- a/examples/async.rs
+++ b/examples/async.rs
@@ -1,10 +1,11 @@
 //! This example demonstrates the use of `send_async()` to make a request
 //! asynchronously using the futures-based API.
 
+use futures_lite::future::block_on;
 use isahc::prelude::*;
 
 fn main() -> Result<(), isahc::Error> {
-    futures_lite::future::block_on(async {
+    block_on(async {
         let mut response = isahc::get_async("http://example.org").await?;
 
         println!("Status: {}", response.status());

--- a/src/body/mod.rs
+++ b/src/body/mod.rs
@@ -1,6 +1,7 @@
 //! Provides types for working with request and response bodies.
 
-use futures_lite::io::{AsyncRead, BlockOn};
+use crate::util::{future::FutureExt, io::read_async};
+use futures_io::AsyncRead;
 use std::{
     borrow::Cow,
     fmt,
@@ -174,13 +175,21 @@ impl AsyncBody {
     /// generally if the underlying reader only supports blocking under a
     /// specific runtime.
     pub(crate) fn into_sync(self) -> sync::Body {
+        struct ReadSyncAdapter<T>(T);
+
+        impl<T: AsyncRead + Unpin> Read for ReadSyncAdapter<T> {
+            fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+                read_async(&mut self.0, buf).wait()
+            }
+        }
+
         match self.0 {
             Inner::Empty => sync::Body::empty(),
             Inner::Buffer(cursor) => sync::Body::from_bytes_static(cursor.into_inner()),
             Inner::Reader(reader, Some(len)) => {
-                sync::Body::from_reader_sized(BlockOn::new(reader), len)
+                sync::Body::from_reader_sized(ReadSyncAdapter(reader), len)
             }
-            Inner::Reader(reader, None) => sync::Body::from_reader(BlockOn::new(reader)),
+            Inner::Reader(reader, None) => sync::Body::from_reader(ReadSyncAdapter(reader)),
         }
     }
 }
@@ -258,7 +267,7 @@ mod tests {
     use super::*;
     use futures_lite::{
         future::{block_on, zip},
-        io::AsyncReadExt,
+        io::{empty, AsyncReadExt},
     };
 
     static_assertions::assert_impl_all!(AsyncBody: Send, Sync);
@@ -281,7 +290,7 @@ mod tests {
 
     #[test]
     fn reader_with_unknown_length() {
-        let body = AsyncBody::from_reader(futures_lite::io::empty());
+        let body = AsyncBody::from_reader(empty());
 
         assert!(!body.is_empty());
         assert_eq!(body.len(), None);
@@ -289,7 +298,7 @@ mod tests {
 
     #[test]
     fn reader_with_known_length() {
-        let body = AsyncBody::from_reader_sized(futures_lite::io::empty(), 0);
+        let body = AsyncBody::from_reader_sized(empty(), 0);
 
         assert!(!body.is_empty());
         assert_eq!(body.len(), Some(0));

--- a/src/body/sync.rs
+++ b/src/body/sync.rs
@@ -1,5 +1,6 @@
 use super::AsyncBody;
-use futures_lite::{future::yield_now, io::AsyncWriteExt};
+use crate::util::io::write_all_async;
+use futures_lite::future::yield_now;
 use sluice::pipe::{pipe, PipeWriter};
 use std::{
     borrow::Cow,
@@ -275,7 +276,7 @@ impl Writer {
                 Err(e) => return Err(e),
             };
 
-            self.writer.write_all(&buf[..len]).await?;
+            write_all_async(&mut self.writer, &buf[..len]).await?;
         }
     }
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -11,7 +11,7 @@ use crate::{
 use async_channel::Sender;
 use curl::easy::{Easy2, InfoType, ReadError, SeekResult, WriteError};
 use curl_sys::CURL;
-use futures_lite::io::{AsyncRead, AsyncWrite};
+use futures_io::{AsyncRead, AsyncWrite};
 use http::Response;
 use once_cell::sync::OnceCell;
 use sluice::pipe;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -261,9 +261,9 @@ mod parsing;
 mod redirect;
 mod request;
 mod response;
-mod task;
 mod text;
 mod trailer;
+mod util;
 
 pub mod auth;
 pub mod config;

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,5 +1,10 @@
-use crate::{metrics::Metrics, redirect::EffectiveUri, trailer::Trailer};
-use futures_lite::io::{copy as copy_async, AsyncRead, AsyncWrite};
+use crate::{
+    metrics::Metrics,
+    redirect::EffectiveUri,
+    trailer::Trailer,
+    util::io::{copy_async, Sink},
+};
+use futures_io::{AsyncRead, AsyncWrite};
 use http::{Response, Uri};
 use std::{
     fs::File,
@@ -452,7 +457,7 @@ pub trait AsyncReadResponseExt<R: AsyncRead + Unpin> {
 impl<R: AsyncRead + Unpin> AsyncReadResponseExt<R> for Response<R> {
     fn consume(&mut self) -> ConsumeFuture<'_, R> {
         ConsumeFuture::new(async move {
-            copy_async(self.body_mut(), futures_lite::io::sink()).await?;
+            copy_async(self.body_mut(), Sink).await?;
 
             Ok(())
         })

--- a/src/text.rs
+++ b/src/text.rs
@@ -2,9 +2,9 @@
 
 #![cfg(feature = "text-decoding")]
 
-use crate::headers::HasHeaders;
+use crate::{headers::HasHeaders, util::io::read_async};
 use encoding_rs::{CoderResult, Encoding};
-use futures_lite::io::{AsyncRead, AsyncReadExt};
+use futures_io::AsyncRead;
 use http::Response;
 use std::io;
 
@@ -85,7 +85,7 @@ impl Decoder {
     where
         R: AsyncRead + Unpin + 'r,
     {
-        TextFuture::new(async move { decode_reader!(self, buf, reader.read(buf).await) })
+        TextFuture::new(async move { decode_reader!(self, buf, read_async(&mut reader, buf).await) })
     }
 
     /// Push additional bytes into the decoder, returning any trailing bytes

--- a/src/util/future.rs
+++ b/src/util/future.rs
@@ -1,0 +1,58 @@
+//! Tiny module containing utilities for working with futures.
+
+use crossbeam_utils::sync::Parker;
+use futures_lite::pin;
+use std::{
+    cell::RefCell,
+    future::Future,
+    task::{Context, Poll, Waker},
+};
+use waker_fn::waker_fn;
+
+pub(crate) trait FutureExt: Future {
+    /// Block the current thread until this future completes.
+    fn wait(self) -> <Self as Future>::Output
+    where
+        Self: Sized,
+    {
+        fn create_parker() -> (Parker, Waker) {
+            let parker = Parker::new();
+            let unparker = parker.unparker().clone();
+            let waker = waker_fn(move || unparker.unpark());
+
+            (parker, waker)
+        }
+
+        thread_local! {
+            static PARKER: RefCell<(Parker, Waker)> = RefCell::new(create_parker());
+        }
+
+        let future = self;
+        pin!(future);
+
+        PARKER.with(|cell| {
+            if let Ok(borrow) = cell.try_borrow_mut() {
+                let mut cx = Context::from_waker(&borrow.1);
+
+                loop {
+                    match future.as_mut().poll(&mut cx) {
+                        Poll::Ready(result) => break result,
+                        Poll::Pending => borrow.0.park(),
+                    }
+                }
+            } else {
+                let (parker, waker) = create_parker();
+                let mut cx = Context::from_waker(&waker);
+
+                loop {
+                    match future.as_mut().poll(&mut cx) {
+                        Poll::Ready(result) => break result,
+                        Poll::Pending => parker.park(),
+                    }
+                }
+            }
+        })
+    }
+}
+
+impl<F: Future> FutureExt for F {}

--- a/src/util/io.rs
+++ b/src/util/io.rs
@@ -1,0 +1,87 @@
+//! Very tiny module containing helpers for `AsyncRead` and `AsyncWrite`.
+
+use futures_io::{AsyncRead, AsyncWrite};
+use futures_lite::{
+    future::{poll_fn, yield_now},
+    pin,
+};
+use std::{
+    io::{ErrorKind, Result},
+    pin::Pin,
+    task::{Context, Poll},
+};
+
+pub(crate) async fn read_async<R>(reader: &mut R, buf: &mut [u8]) -> Result<usize>
+where
+    R: AsyncRead + Unpin,
+{
+    pin!(reader);
+
+    poll_fn(|cx| reader.as_mut().poll_read(cx, buf)).await
+}
+
+pub(crate) async fn write_async<R>(writer: &mut R, buf: &[u8]) -> Result<usize>
+where
+    R: AsyncWrite + Unpin,
+{
+    pin!(writer);
+
+    poll_fn(|cx| writer.as_mut().poll_write(cx, buf)).await
+}
+
+pub(crate) async fn write_all_async<R>(writer: &mut R, buf: &[u8]) -> Result<usize>
+where
+    R: AsyncWrite + Unpin,
+{
+    let mut amt = 0;
+
+    while amt < buf.len() {
+        match write_async(writer, &buf[amt..]).await {
+            Ok(0) => return Err(ErrorKind::WriteZero.into()),
+            Ok(len) => amt += len,
+            Err(e) if e.kind() == ErrorKind::Interrupted => yield_now().await,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(amt)
+}
+
+pub(crate) async fn copy_async<R, W>(mut reader: R, mut writer: W) -> Result<u64>
+where
+    R: AsyncRead + Unpin,
+    W: AsyncWrite + Unpin,
+{
+    let mut buf = [0; 8192];
+
+    let mut amt = 0;
+
+    loop {
+        match read_async(&mut reader, &mut buf).await {
+            Ok(0) => break,
+            Ok(len) => {
+                amt += write_all_async(&mut writer, &buf[..len]).await? as u64;
+            }
+            Err(e) if e.kind() == ErrorKind::Interrupted => yield_now().await,
+            Err(e) => return Err(e),
+        }
+    }
+
+    Ok(amt)
+}
+
+pub(crate) struct Sink;
+
+impl AsyncWrite for Sink {
+    fn poll_write(self: Pin<&mut Self>, _cx: &mut Context, buf: &[u8]) -> Poll<Result<usize>> {
+        Poll::Ready(Ok(buf.len()))
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_close(self: Pin<&mut Self>, _cx: &mut Context) -> Poll<Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,24 @@
+use std::ops::Deref;
+
 pub(crate) mod future;
 pub(crate) mod io;
 pub(crate) mod task;
+
+enum MaybeOwned<T, B> {
+    Owned(T),
+    Borrowed(B),
+}
+
+impl<T, B> Deref for MaybeOwned<T, B>
+where
+    B: Deref<Target = T>,
+{
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Owned(ref value) => value,
+            Self::Borrowed(borrow) => borrow.deref(),
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod future;
+pub(crate) mod io;
+pub(crate) mod task;

--- a/src/util/task.rs
+++ b/src/util/task.rs
@@ -1,6 +1,7 @@
-//! Helpers for working with tasks and futures.
+//! Helpers for working with tasks.
 
 use std::task::Waker;
+use waker_fn::waker_fn;
 
 /// Helper methods for working with wakers.
 pub(crate) trait WakerExt {
@@ -12,6 +13,6 @@ pub(crate) trait WakerExt {
 impl WakerExt for Waker {
     fn chain(&self, f: impl Fn(&Waker) + Send + Sync + 'static) -> Waker {
         let inner = self.clone();
-        waker_fn::waker_fn(move || (f)(&inner))
+        waker_fn(move || (f)(&inner))
     }
 }

--- a/tests/json.rs
+++ b/tests/json.rs
@@ -1,6 +1,7 @@
 #![cfg(feature = "json")]
 
-use futures_lite::{future::block_on, io::AsyncRead};
+use futures_io::AsyncRead;
+use futures_lite::future::block_on;
 use isahc::prelude::*;
 use serde_json::Value;
 use std::{

--- a/tests/request_body.rs
+++ b/tests/request_body.rs
@@ -1,4 +1,5 @@
-use futures_lite::{future::block_on, AsyncRead};
+use futures_io::AsyncRead;
+use futures_lite::future::block_on;
 use isahc::{prelude::*, AsyncBody, Body, Request};
 use std::{
     error::Error,


### PR DESCRIPTION
Disable default features in `futures-lite` which require several dependencies that are actually unnecessary for the very few things we use from it. Re-implement these few features instead.