### PR TITLE
More PSL internal refactoring

### DIFF
--- a/src/cookies/psl/mod.rs
+++ b/src/cookies/psl/mod.rs
@@ -20,14 +20,12 @@
 //! since a stale list is better than no list at all.
 
 use crate::{request::RequestExt, ReadResponseExt};
+use crossbeam_utils::atomic::AtomicCell;
 use once_cell::sync::Lazy;
 use publicsuffix::{List, Psl};
 use std::{
     error::Error,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        RwLock,
-    },
+    sync::{Arc, RwLock},
     thread,
     time::{Duration, SystemTime},
 };
@@ -36,31 +34,41 @@ use std::{
 static TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Global in-memory PSL cache.
-static CACHE: Lazy<RwLock<ListCache>> = Lazy::new(Default::default);
+static CACHE: Lazy<ListCache> = Lazy::new(Default::default);
 
+#[derive(Clone)]
 struct ListCache {
+    inner: Arc<RwLock<Inner>>,
+}
+
+struct Inner {
     list: List,
     last_refreshed: Option<SystemTime>,
-    last_updated: Option<SystemTime>,
+    last_modified: Option<SystemTime>,
+    is_refreshing: AtomicCell<bool>,
 }
 
 impl Default for ListCache {
     fn default() -> Self {
         Self {
-            // Use a bundled version of the list. We bundle using a Git
-            // submodule instead of downloading it from the Internet during the
-            // build, because that would force you to have an active Internet
-            // connection in order to compile. And that would be really
-            // annoying, especially if you are on a slow connection.
-            list: include_str!("list/public_suffix_list.dat")
-                .parse()
-                .expect("could not parse bundled public suffix list"),
+            inner: Arc::new(RwLock::new(Inner {
+                // Use a bundled version of the list. We bundle using a Git
+                // submodule instead of downloading it from the Internet during the
+                // build, because that would force you to have an active Internet
+                // connection in order to compile. And that would be really
+                // annoying, especially if you are on a slow connection.
+                list: include_str!("list/public_suffix_list.dat")
+                    .parse()
+                    .expect("could not parse bundled public suffix list"),
 
-            // Refresh the list right away.
-            last_refreshed: None,
+                // Refresh the list right away.
+                last_refreshed: Default::default(),
 
-            // Assume the bundled list is always out of date.
-            last_updated: None,
+                // Assume the bundled list is always out of date.
+                last_modified: Default::default(),
+
+                is_refreshing: Default::default(),
+            })),
         }
     }
 }
@@ -70,7 +78,10 @@ impl ListCache {
     fn is_public_suffix(&self, domain: &str) -> bool {
         let domain = domain.as_bytes();
 
-        self.list
+        self.inner
+            .read()
+            .unwrap()
+            .list
             .suffix(domain)
             // We don't want to block unknown hosts like `localhost`
             .filter(publicsuffix::Suffix::is_known)
@@ -78,6 +89,71 @@ impl ListCache {
             .is_some()
     }
 
+    fn refresh(&self) -> Result<(), Box<dyn Error>> {
+        let mut inner = self.inner.write().unwrap();
+        let mut request = http::Request::get(publicsuffix::LIST_URL);
+
+        if let Some(last_modified) = inner.last_modified {
+            request = request.header(
+                http::header::IF_MODIFIED_SINCE,
+                httpdate::fmt_http_date(last_modified),
+            );
+        }
+
+        let mut response = request.body(())?.send()?;
+
+        match response.status() {
+            http::StatusCode::OK => {
+                // Parse the suffix list.
+                inner.list = response.text()?.parse()?;
+                tracing::debug!("public suffix list updated");
+            }
+
+            http::StatusCode::NOT_MODIFIED => {
+                tracing::debug!("public suffix list not modified");
+            }
+
+            status => {
+                tracing::warn!(
+                    "could not update public suffix list, got status code {}",
+                    status,
+                );
+                return Ok(());
+            }
+        }
+
+        if let Some(d) = response.headers().get(http::header::LAST_MODIFIED) {
+            inner.last_modified = httpdate::parse_http_date(d.to_str().unwrap()).ok();
+        }
+
+        inner.last_refreshed = Some(SystemTime::now());
+
+        Ok(())
+    }
+
+    fn refresh_in_background(&self, force: bool) {
+        let inner = self.inner.read().unwrap();
+
+        if !force && !inner.needs_refreshed() {
+            return;
+        }
+
+        // Only spawn a refresh thread if one isn't already running.
+        if inner.is_refreshing.compare_exchange(false, true).is_ok() {
+            let cache = self.clone();
+
+            thread::spawn(move || {
+                if let Err(e) = cache.refresh() {
+                    tracing::warn!("could not refresh public suffix list: {}", e);
+                }
+
+                cache.inner.read().unwrap().is_refreshing.store(false);
+            });
+        }
+    }
+}
+
+impl Inner {
     fn needs_refreshed(&self) -> bool {
         match self.last_refreshed {
             Some(last_refreshed) => match last_refreshed.elapsed() {
@@ -87,46 +163,6 @@ impl ListCache {
             None => true,
         }
     }
-
-    fn refresh(&mut self) -> Result<(), Box<dyn Error>> {
-        let result = self.try_refresh();
-        self.last_refreshed = Some(SystemTime::now());
-        result
-    }
-
-    fn try_refresh(&mut self) -> Result<(), Box<dyn Error>> {
-        let mut request = http::Request::get(publicsuffix::LIST_URL);
-
-        if let Some(last_updated) = self.last_updated {
-            request = request.header(
-                http::header::IF_MODIFIED_SINCE,
-                httpdate::fmt_http_date(last_updated),
-            );
-        }
-
-        let mut response = request.body(())?.send()?;
-
-        match response.status() {
-            http::StatusCode::OK => {
-                // Parse the suffix list.
-                self.list = response.text()?.parse()?;
-                self.last_updated = Some(SystemTime::now());
-                tracing::debug!("public suffix list updated");
-            }
-
-            http::StatusCode::NOT_MODIFIED => {
-                // List hasn't changed and is still new.
-                self.last_updated = Some(SystemTime::now());
-            }
-
-            status => tracing::warn!(
-                "could not update public suffix list, got status code {}",
-                status,
-            ),
-        }
-
-        Ok(())
-    }
 }
 
 /// Determine if the given domain is a public suffix.
@@ -135,34 +171,11 @@ impl ListCache {
 /// triggered. The current data will be used to respond to this query.
 pub(crate) fn is_public_suffix(domain: impl AsRef<str>) -> bool {
     let domain = domain.as_ref();
-    let cache = CACHE.read().unwrap();
 
-    // Check if the list needs to be refreshed.
-    if cache.needs_refreshed() {
-        refresh_in_background();
-    }
+    // Refresh the list if needed.
+    CACHE.refresh_in_background(false);
 
-    cache.is_public_suffix(domain)
-}
-
-fn refresh_in_background() {
-    static IS_REFRESHING: AtomicBool = AtomicBool::new(false);
-
-    // Only spawn a refresh thread if one isn't already running.
-    if IS_REFRESHING
-        .compare_exchange(false, true, Ordering::SeqCst, Ordering::SeqCst)
-        .is_ok()
-    {
-        thread::spawn(|| {
-            let mut cache = CACHE.write().unwrap();
-
-            if let Err(e) = cache.refresh() {
-                tracing::warn!("could not refresh public suffix list: {}", e);
-            }
-
-            IS_REFRESHING.store(false, Ordering::SeqCst);
-        });
-    }
+    CACHE.is_public_suffix(domain)
 }
 
 #[cfg(test)]
@@ -173,27 +186,32 @@ mod tests {
 
     #[test]
     fn refresh_cache() {
-        // Reset cache.
-        *CACHE.write().unwrap() = Default::default();
+        let cache = ListCache::default();
 
-        assert!(CACHE.read().unwrap().last_refreshed.is_none());
-        assert!(CACHE.read().unwrap().last_updated.is_none());
-        assert!(CACHE.read().unwrap().needs_refreshed());
+        assert!(cache.inner.read().unwrap().last_refreshed.is_none());
+        assert!(cache.inner.read().unwrap().last_modified.is_none());
+        assert!(cache.inner.read().unwrap().needs_refreshed());
 
-        refresh_in_background();
-        sleep(Duration::from_millis(200));
+        cache.refresh_in_background(true);
 
-        assert!(CACHE.read().unwrap().last_refreshed.is_some());
-        assert!(CACHE.read().unwrap().last_updated.is_some());
-        assert!(!CACHE.read().unwrap().needs_refreshed());
+        while cache.inner.read().unwrap().is_refreshing.load() {
+            sleep(Duration::from_millis(100));
+        }
 
-        let last_refreshed = CACHE.read().unwrap().last_refreshed.unwrap();
-        let last_updated = CACHE.read().unwrap().last_updated.unwrap();
+        assert!(cache.inner.read().unwrap().last_refreshed.is_some());
+        assert!(cache.inner.read().unwrap().last_modified.is_some());
+        assert!(!cache.inner.read().unwrap().needs_refreshed());
 
-        refresh_in_background();
-        sleep(Duration::from_millis(200));
+        let last_refreshed = cache.inner.read().unwrap().last_refreshed.unwrap();
+        let last_modified = cache.inner.read().unwrap().last_modified.unwrap();
 
-        assert!(CACHE.read().unwrap().last_refreshed.unwrap() > last_refreshed);
-        assert!(CACHE.read().unwrap().last_updated.unwrap() > last_updated);
+        cache.refresh_in_background(true);
+
+        while cache.inner.read().unwrap().is_refreshing.load() {
+            sleep(Duration::from_millis(100));
+        }
+
+        assert!(cache.inner.read().unwrap().last_refreshed.unwrap() > last_refreshed);
+        assert!(cache.inner.read().unwrap().last_modified.unwrap() >= last_modified);
     }
 }


### PR DESCRIPTION
Make PSL system less reliant on statics and easier to reliably test. In the future we might do more internal refactoring to make the PSL cache tied to individual clients, but I'm saving that for later.