### PR TITLE
Adds optional `pkcs11` feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ cookies = ["httpdate"]
 http2 = ["curl/http2"]
 json = ["serde", "serde_json"]
 nightly = []
+pkcs11 = ["pk11-uri-parser"]
 psl = ["httpdate", "parking_lot", "publicsuffix"]
 spnego = ["curl-sys/spnego"]
 static-curl = ["curl/static-curl"]
@@ -62,6 +63,10 @@ optional = true
 
 [dependencies.parking_lot]
 version = ">=0.9.0, <0.12.0"
+optional = true
+
+[dependencies.pk11-uri-parser]
+version = "0.1.5"
 optional = true
 
 [dependencies.publicsuffix]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,11 @@
 //! Additional serialization and deserialization of JSON bodies via
 //! [serde](https://serde.rs). Disabled by default.
 //!
+//! ## `pkcs11`
+//!
+//! Enable certificate and private key configuration for PKCS#11 token
+//! usage. Disabled by default.
+//!
 //! ## `psl`
 //!
 //! Enable use of the Public Suffix List to filter out potentially malicious


### PR DESCRIPTION
Adds backward compatible  `easy.ssl_engine` functionality for pkcs11 resources.