### PR TITLE
Prevent a segmentation fault by making `is_bad_socket_error` return `true` on `std::io::ErrorKind::PermissionDenied`

### DIFF
--- a/src/agent/selector.rs
+++ b/src/agent/selector.rs
@@ -125,7 +125,7 @@ impl Selector {
             // error back complaining that the socket is invalid, we can safely
             // ignore it.
             if let Err(e) = self.poller.delete(socket) {
-                if !is_bad_socket_error(&e) && e.kind() != io::ErrorKind::PermissionDenied {
+                if !is_bad_socket_error(&e) {
                     return Err(e);
                 }
             }
@@ -267,7 +267,7 @@ fn is_bad_socket_error(error: &io::Error) -> bool {
 
     match error.kind() {
         // Common error codes std understands.
-        io::ErrorKind::NotFound | io::ErrorKind::InvalidInput => true,
+        io::ErrorKind::NotFound | io::ErrorKind::InvalidInput | io::ErrorKind::PermissionDenied => true,
 
         // Check for OS-specific error codes.
         _ => match error.raw_os_error() {


### PR DESCRIPTION
As described in the issue https://github.com/sagebind/isahc/issues/460, `isahc::agent::AgentContext::register` returns a `std::io::Result::Err`, if `isahc::agent::selector::is_bad_socket_error` returns `false`. `isahc::agent::AgentContext::poll` then calls the `std::io::Result::unwrap` method on the `Err` variant. This causes a panic and that in turn causes a segmentation fault. I think there two bigger issues here:

1. panic handling should be improved so that a panic does not cause a segmentation fault,
2. and `isahc::agent::AgentContext::poll` should not call `unwrap`.

This pull request is not a fix for either of those issues. Instead, it is a proposal for a minimal change that fixes one case where issues 1 and 2 manifest.

I am unsure, if this is a good fix. I am not familiar with the polling backends that `polling` uses. I do not know what it means for `poller.add` and/or `poller.modify` to return a `std::io::Result::Err` variant whose `std::io::Error::kind` method returns a `std::io::ErrorKind::PermissionDenied` variant. But the panic and the subsequent segmentation fault are prevented, if `is_bad_socket_error` returns `true` in that case.

Possible ramifications of returning `true` on `std::io::ErrorKind::PermissionDenied` are unknown to me. What if `poller.add` or `poller.modify` constantly return `PermissionDenied` due to insufficient user privileges? Is it possible for that to cause an infinite loop of trying to call `poller.add` or `poller.modify` and them returing `PermissionDenied` over and over again?

The `segfault` integration test and the associated `run-segfault-integration-test-repeatedly.sh` script, available in the pull request https://github.com/sagebind/isahc/pull/461, can be used to test that the fix introduced in this pull request prevents a panic and the subsequent segmentation fault.
