### PR TITLE
Workaround for segfault in curl-rust when dropping agent context

### DIFF
--- a/src/agent/mod.rs
+++ b/src/agent/mod.rs
@@ -553,6 +553,18 @@ impl AgentContext {
     }
 }
 
+impl Drop for AgentContext {
+    fn drop(&mut self) {
+        // Due to a bug present in some versions of curl-rust, dropping an
+        // easy handle after its associated multi handle has already been
+        // dropped can cause a segfault. As a workaround, explicitly drop all
+        // easy handles here first before the multi handle is dropped, if any.
+        //
+        // See https://github.com/sagebind/isahc/issues/459 for more details.
+        self.requests.clear();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;


### PR DESCRIPTION
Implement a workaround for a bug in curl-rust where dropping an `Easy2Handle` after its attached `Multi` has already been dropped can cause a segfault, if that handle has one or more open sockets with pending operations. Our workaround is to ensure that we drop all easy handles first before proceeding with the normal drop order.

I have also proposed a fix for this bug upstream (<https://github.com/alexcrichton/curl-rust/pull/645>), but that will only apply to future versions of curl-rust. This workaround here in Isahc will avoid the issue for all versions of curl-rust that are affected by this bug that a user may be using.

This should fix https://github.com/sagebind/isahc/issues/459.