### PR TITLE
Fix empty request body resulting in a zero-length stream for POST and PUT

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -1086,11 +1086,11 @@ impl HttpClient {
                 easy.nobody(true)?;
             }
             // POST requests have special redirect behavior.
-            (&http::Method::POST, _) => {
+            (&http::Method::POST, true) => {
                 easy.post(true)?;
             }
             // Normal PUT request.
-            (&http::Method::PUT, _) => {
+            (&http::Method::PUT, true) => {
                 easy.upload(true)?;
             }
             // Default case is to either treat request like a GET or PUT.

--- a/tests/request_body.rs
+++ b/tests/request_body.rs
@@ -1,5 +1,5 @@
-use futures_lite::{future::block_on, AsyncRead};
-use isahc::{prelude::*, AsyncBody, Body, Request};
+use futures_lite::{AsyncRead, future::block_on};
+use isahc::{AsyncBody, Body, Request, prelude::*};
 use std::{
     error::Error,
     io::{self, Read},
@@ -11,6 +11,65 @@ use testserver::mock;
 
 #[macro_use]
 mod utils;
+
+#[test_case("GET")]
+#[test_case("HEAD")]
+#[test_case("POST")]
+#[test_case("PUT")]
+#[test_case("DELETE")]
+#[test_case("PATCH")]
+#[test_case("FOOBAR")]
+fn request_with_zero_length_body(method: &str) {
+    let m = mock!();
+
+    Request::builder()
+        .method(method)
+        .uri(m.url())
+        .header("Content-Type", "application/json")
+        .body(Body::from(&[] as &[u8]))
+        .unwrap()
+        .send()
+        .unwrap();
+
+    assert_eq!(m.request().method(), method);
+    m.request().expect_header("content-length", "0");
+    m.request()
+        .expect_header("content-type", "application/json");
+    m.request().expect_body(&[]);
+}
+
+#[test_case("GET")]
+#[test_case("HEAD")]
+#[test_case("POST")]
+#[test_case("PUT")]
+#[test_case("DELETE")]
+#[test_case("PATCH")]
+#[test_case("FOOBAR")]
+fn request_with_special_empty_body_does_not_send_a_body(method: &str) {
+    let m = mock!();
+
+    Request::builder()
+        .method(method)
+        .uri(m.url())
+        .header("Content-Type", "application/json")
+        .body(Body::empty())
+        .unwrap()
+        .send()
+        .unwrap();
+
+    assert_eq!(m.request().method(), method);
+
+    // There should be no headers sent to the server to indicate that a body
+    // will be sent.
+    assert_eq!(m.request().get_header("content-length").count(), 0);
+    assert_eq!(m.request().get_header("transfer-encoding").count(), 0);
+
+    m.request()
+        .expect_header("content-type", "application/json");
+
+    // For HTTP/1.1, reading after the header should just be an immediate EOF.
+    m.request().expect_body(&[]);
+}
 
 #[test_case("GET")]
 #[test_case("HEAD")]


### PR DESCRIPTION
Due to what I suspect is a change in libcurl behavior since our code was last implemented, for `POST` and `PUT` requests only, sending a request using `Body::empty()` results in a request being sent to the server with `Transfer-Encoding: chunked` and a zero-length body, instead of no body at all.

To fix this, always set `custom_request` when we know that we are trying to _not_ send a body for a `POST` or `PUT` request type. This will cause libcurl to treat the request more like a `GET` request despite having a recognizable method name that usually includes a body.

I've added a test that fails due to this invalid behavior, which should now pass.

Fixes #452.