### PR TITLE
Block curl 8.20.0 and add sanity checks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,8 +62,10 @@ version = "0.4.43"
 default-features = false
 
 [dependencies.curl-sys]
-# Minimum version for rustls-platform-verifier support is 0.4.81
-version = "0.4.81"
+# Minimum version for rustls-platform-verifier support is 0.4.81.
+# 0.4.88 bundles libcurl 8.20.0 which has a DNS resolver bug that affects us
+# severely, so we exclude it.
+version = ">=0.4.81, <0.4.88"
 default-features = false
 
 [dependencies.encoding_rs]

--- a/src/client.rs
+++ b/src/client.rs
@@ -94,6 +94,11 @@ impl HttpClientBuilder {
     ///
     /// This is equivalent to the [`Default`] implementation.
     pub fn new() -> Self {
+        // This is a good a time as any to do some sanity checks against the
+        // version of curl we find ourselves linked to, before the user attempts
+        // to use an HTTP client.
+        crate::info::do_curl_sanity_checks();
+
         Self {
             agent_builder: AgentBuilder::default(),
             client_config: ClientConfig::default(),

--- a/src/info.rs
+++ b/src/info.rs
@@ -75,7 +75,7 @@ pub(crate) fn do_curl_sanity_checks() {
         panic!("libcurl 8.20.0 detected, this version has a known bug that causes DNS to hang");
     }
 
-    if curl_info().protocols().find(|&p| p == "http").is_none() {
+    if !curl_info().protocols().any(|p| p == "http") {
         panic!("linked libcurl does not support HTTP");
     }
 }

--- a/src/info.rs
+++ b/src/info.rs
@@ -7,6 +7,11 @@ use std::sync::LazyLock;
 ///
 /// This function can be helpful when troubleshooting issues in Isahc or one of
 /// its dependencies.
+///
+/// # Stability
+///
+/// The format of this string should *not* be considered stable, and should only
+/// be used for display, diagnostic, or debugging purposes.
 pub fn version() -> &'static str {
     static VERSION_STRING: LazyLock<String> = LazyLock::new(|| {
         format!(
@@ -61,6 +66,18 @@ pub(crate) fn curl_version() -> (u8, u8, u8) {
     let bits = curl_info().version_num();
 
     ((bits >> 16) as u8, (bits >> 8) as u8, bits as u8)
+}
+
+/// Inspect at runtime the version of curl Isahc is linked to and perform sanity
+/// checks to ensure it is something that we can use.
+pub(crate) fn do_curl_sanity_checks() {
+    if curl_version() == (8, 20, 0) {
+        panic!("libcurl 8.20.0 detected, this version has a known bug that causes DNS to hang");
+    }
+
+    if curl_info().protocols().find(|&p| p == "http").is_none() {
+        panic!("linked libcurl does not support HTTP");
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Block curl-sys from providing a bundled curl 8.20.0, which has a bug that causes DNS to hang on Windows (and potentially other platforms too, depending on how curl is compiled). Additionally, add some additional runtime sanity checks that verify the curl we are linked to is actually useful. I expect more checks can be added to this in the future as needed. This should not be necessary very often when using `static-curl`, but if that is disabled and we're using a system curl instead, then weird things are certainly possible.