### PR TITLE
Move net-related types into net module

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -14,6 +14,7 @@ use crate::{
     handler::{RequestHandler, ResponseBodyReader, ResponseResult},
     headers::HasHeaders,
     interceptor::{self, Interceptor, InterceptorObj},
+    net::dns::{DnsCache, ResolveMap},
     parsing::header_to_curl_string,
 };
 use futures_lite::{
@@ -265,7 +266,7 @@ impl HttpClientBuilder {
     /// # Examples
     ///
     /// ```
-    /// use isahc::{config::*, prelude::*, HttpClient};
+    /// use isahc::{net::dns::DnsCache, prelude::*, HttpClient};
     /// use std::time::Duration;
     ///
     /// let client = HttpClient::builder()
@@ -301,7 +302,7 @@ impl HttpClientBuilder {
     /// # Examples
     ///
     /// ```
-    /// use isahc::{config::ResolveMap, prelude::*, HttpClient};
+    /// use isahc::{net::dns::ResolveMap, prelude::*, HttpClient};
     /// use std::net::IpAddr;
     ///
     /// let client = HttpClient::builder()

--- a/src/config/client.rs
+++ b/src/config/client.rs
@@ -1,7 +1,5 @@
-use super::{
-    dns::{DnsCache, ResolveMap},
-    setopt::{EasyHandle, SetOpt, SetOptError},
-};
+use super::setopt::{EasyHandle, SetOpt, SetOptError};
+use crate::net::dns::{DnsCache, ResolveMap};
 use std::time::Duration;
 
 #[derive(Debug, Default)]

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,21 +16,17 @@
 use crate::{
     auth::{Authentication, Credentials},
     is_http_version_supported,
-    net::interface,
+    net::{Dialer, IpVersion, interface},
 };
 use setopt::{EasyHandle, SetOpt, SetOptError};
 use std::time::Duration;
 
 pub(crate) mod client;
-pub(crate) mod dial;
-pub(crate) mod dns;
 pub(crate) mod proxy;
 pub(crate) mod redirect;
 pub(crate) mod request;
 pub(crate) mod setopt;
 
-pub use dial::{Dialer, DialerParseError};
-pub use dns::{DnsCache, ResolveMap};
 pub use redirect::RedirectPolicy;
 
 /// Provides additional methods when building a request for configuring various
@@ -426,7 +422,7 @@ pub trait Configurable: request::WithRequestConfig {
     ///
     /// ```
     /// use isahc::{
-    ///     config::Dialer,
+    ///     net::Dialer,
     ///     prelude::*,
     ///     Request,
     /// };
@@ -442,7 +438,7 @@ pub trait Configurable: request::WithRequestConfig {
     ///
     /// ```
     /// use isahc::{
-    ///     config::Dialer,
+    ///     net::Dialer,
     ///     prelude::*,
     ///     Request,
     /// };
@@ -856,40 +852,6 @@ impl SetOpt for VersionNegotiation {
                 easy.http_version(version).map_err(Into::into)
             }
         }
-    }
-}
-
-/// Supported IP versions that can be used.
-#[derive(Clone, Debug)]
-pub enum IpVersion {
-    /// Use IPv4 addresses only. IPv6 addresses will be ignored.
-    V4,
-
-    /// Use IPv6 addresses only. IPv4 addresses will be ignored.
-    V6,
-
-    /// Use either IPv4 or IPv6 addresses. By default IPv6 addresses are
-    /// preferred if available, otherwise an IPv4 address will be used. IPv6
-    /// addresses are tried first by following the recommendations of [RFC
-    /// 6555 "Happy Eyeballs"](https://tools.ietf.org/html/rfc6555).
-    Any,
-}
-
-impl Default for IpVersion {
-    fn default() -> Self {
-        Self::Any
-    }
-}
-
-impl SetOpt for IpVersion {
-    fn set_opt(&self, easy: &mut EasyHandle) -> Result<(), SetOptError> {
-        easy.ip_resolve(match &self {
-            IpVersion::V4 => curl::easy::IpResolve::V4,
-            IpVersion::V6 => curl::easy::IpResolve::V6,
-            IpVersion::Any => curl::easy::IpResolve::Any,
-        })?;
-
-        Ok(())
     }
 }
 

--- a/src/net/dial.rs
+++ b/src/net/dial.rs
@@ -1,7 +1,7 @@
 //! Configuration for customizing how connections are established and sockets
 //! are opened.
 
-use super::setopt::{EasyHandle, SetOpt, SetOptError};
+use crate::config::setopt::{EasyHandle, SetOpt, SetOptError};
 use curl::easy::List;
 use http::Uri;
 use std::{convert::TryFrom, fmt, net::SocketAddr, str::FromStr};
@@ -35,11 +35,11 @@ impl std::error::Error for DialerParseError {}
 /// Connect to a Unix socket URI:
 ///
 /// ```
-/// use isahc::config::Dialer;
+/// use isahc::net::Dialer;
 ///
 /// # #[cfg(unix)]
 /// let unix_socket = "unix:/path/to/my.sock".parse::<Dialer>()?;
-/// # Ok::<(), isahc::config::DialerParseError>(())
+/// # Ok::<(), isahc::net::DialerParseError>(())
 /// ```
 #[derive(Clone, Debug)]
 pub struct Dialer(Inner);
@@ -63,14 +63,14 @@ impl Dialer {
     /// # Examples
     ///
     /// ```
-    /// use isahc::config::Dialer;
+    /// use isahc::net::Dialer;
     /// use std::net::Ipv4Addr;
     ///
     /// let dialer = Dialer::ip_socket((Ipv4Addr::LOCALHOST, 8080));
     /// ```
     ///
     /// ```
-    /// use isahc::config::Dialer;
+    /// use isahc::net::Dialer;
     /// use std::net::SocketAddr;
     ///
     /// let dialer = Dialer::ip_socket("0.0.0.0:8765".parse::<SocketAddr>()?);
@@ -90,7 +90,7 @@ impl Dialer {
     /// # Examples
     ///
     /// ```
-    /// use isahc::config::Dialer;
+    /// use isahc::net::Dialer;
     ///
     /// let docker = Dialer::unix_socket("/var/run/docker.sock");
     /// ```

--- a/src/net/dns.rs
+++ b/src/net/dns.rs
@@ -1,6 +1,6 @@
 //! Configuration of DNS resolution.
 
-use super::setopt::{EasyHandle, SetOpt, SetOptError};
+use crate::config::setopt::{EasyHandle, SetOpt, SetOptError};
 use std::{net::IpAddr, time::Duration};
 
 /// DNS caching configuration.

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,3 +1,43 @@
 //! Types for configuring how HTTP connections interact with the network.
 
+use crate::config::setopt::{EasyHandle, SetOpt, SetOptError};
+
+mod dial;
+pub mod dns;
 pub mod interface;
+
+pub use dial::{Dialer, DialerParseError};
+
+/// Supported IP versions that can be used.
+#[derive(Clone, Debug)]
+pub enum IpVersion {
+    /// Use IPv4 addresses only. IPv6 addresses will be ignored.
+    V4,
+
+    /// Use IPv6 addresses only. IPv4 addresses will be ignored.
+    V6,
+
+    /// Use either IPv4 or IPv6 addresses. By default IPv6 addresses are
+    /// preferred if available, otherwise an IPv4 address will be used. IPv6
+    /// addresses are tried first by following the recommendations of [RFC 6555
+    /// "Happy Eyeballs"](https://tools.ietf.org/html/rfc6555).
+    Any,
+}
+
+impl Default for IpVersion {
+    fn default() -> Self {
+        Self::Any
+    }
+}
+
+impl SetOpt for IpVersion {
+    fn set_opt(&self, easy: &mut EasyHandle) -> Result<(), SetOptError> {
+        easy.ip_resolve(match &self {
+            IpVersion::V4 => curl::easy::IpResolve::V4,
+            IpVersion::V6 => curl::easy::IpResolve::V6,
+            IpVersion::Any => curl::easy::IpResolve::Any,
+        })?;
+
+        Ok(())
+    }
+}

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -1,4 +1,4 @@
-use isahc::{config::IpVersion, error::ErrorKind, prelude::*, Request};
+use isahc::{Request, error::ErrorKind, net::IpVersion, prelude::*};
 use std::{
     io::{self, Read, Write},
     net::{Ipv4Addr, Ipv6Addr, Shutdown, TcpListener, TcpStream, ToSocketAddrs},

--- a/tests/unix.rs
+++ b/tests/unix.rs
@@ -1,6 +1,6 @@
 #![cfg(unix)]
 
-use isahc::{config::Dialer, prelude::*, Request};
+use isahc::{Request, net::Dialer, prelude::*};
 use std::{
     io::{self, Write},
     os::unix::net::UnixListener,


### PR DESCRIPTION
Move all configuration related to the network into the `net` module to ease discoverability and to keep things more organized.