### PR TITLE
Use Nextest in CI with retries

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,10 @@
+[profile.ci]
+fail-fast = false
+
+[[profile.ci.overrides]]
+filter = "binary(tls)"
+retries = {
+    backoff = "fixed",
+    count = 3,
+    delay = "5s",
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,6 +83,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: jdx/mise-action@v3
+
       - name: Install musl toolchain
         run: sudo apt install -y musl-tools
         if: matrix.target == 'x86_64-unknown-linux-musl'
@@ -108,7 +110,7 @@ jobs:
             cargo-${{ matrix.target }}-
 
       - name: Run tests
-        run: cargo test --no-default-features --features ${{ matrix.features }}
+        run: cargo nextest run --profile ci --no-default-features --features ${{ matrix.features }}
 
       - name: Run example program
         run: cargo run --release --example simple --no-default-features --features ${{ matrix.features }}

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,9 @@
+[tools]
+cargo-binstall = "latest"
+
+[tools."cargo:cargo-nextest"]
+version = "latest"
+dependencies = ["cargo-binstall"]
+
+[tasks.test]
+run = "cargo nextest run"


### PR DESCRIPTION
Address flaky tests by adding some retries with backoff by setting up [Nextest](https://nexte.st/). This test harness looks like it has some other pretty other handy features that are useful to us beyond just retries.

It appears that the TLS tests that use `badssl.com` are flaky because `badssl.com` drops connections periodically. It would be nice to run a local version of this test somehow, but given the nature of testing TLS certs specifically this could be difficult.