### PR TITLE
Bump minimum curl-sys version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -539,9 +539,9 @@ dependencies = [
 
 [[package]]
 name = "curl-sys"
-version = "0.4.87+curl-8.19.0"
+version = "0.4.90+curl-8.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61a460380f0ef783703dcbe909107f39c162adeac050d73c850055118b5b6327"
+checksum = "97799a0d220bfb3361e0fe4936966ff8c4b24d65c3f06dfc70d7b680b44e7897"
 dependencies = [
  "cc",
  "libc",
@@ -551,7 +551,7 @@ dependencies = [
  "pkg-config",
  "rustls-ffi",
  "vcpkg",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,10 +62,10 @@ version = "0.4.43"
 default-features = false
 
 [dependencies.curl-sys]
-# Minimum version for rustls-platform-verifier support is 0.4.81.
-# 0.4.88 bundles libcurl 8.20.0 which has a DNS resolver bug that affects us
-# severely, so we exclude it.
-version = ">=0.4.81, <0.4.88"
+# Minimum version for rustls-platform-verifier support is 0.4.81. Versions
+# 0.4.88 and 0.4.89 bundle libcurl 8.20 which has a DNS resolver bug that
+# affects us severely, so 0.4.90 is our minimum version which bundles 8.21.
+version = "0.4.90"
 default-features = false
 
 [dependencies.encoding_rs]


### PR DESCRIPTION
Bump the minimum curl-sys version to 0.4.90, which uses curl version 8.21.0. This allows our version requirement to accept new upgrades automatically.

Ideally, we could upgrade our version requirement to only exclude 0.4.88 and 0.4.89 which are known to not work by pulling in the 8.20.0 with the DNS bug, something like this:

```toml
[dependencies.curl-sys]
version = ">=0.4.81, !0.4.88, !0.4.89, <0.5"
```

Unfortunately Cargo doesn't support anything like that right now (https://github.com/rust-lang/cargo/issues/5286) so our only choice is to make 0.4.90 our new minimum requirement.